### PR TITLE
KeyTestingPatches: Output personalization in hex

### DIFF
--- a/niap-cc/KeyTestingPatches/Android10/0001-Add-logging-for-SP800-derived-passwords-too.patch
+++ b/niap-cc/KeyTestingPatches/Android10/0001-Add-logging-for-SP800-derived-passwords-too.patch
@@ -1,5 +1,5 @@
-From bd84acd97787d76bd87d42b7a8dbc1e164583112 Mon Sep 17 00:00:00 2001
-From: Branden Archer <brarcher@google.com>
+From 044e34b73a24c48a299ed459dfb5e9870e4d5c44 Mon Sep 17 00:00:00 2001
+From: Paul Crowley <paulcrowley@google.com>
 Date: Thu, 6 Aug 2020 22:54:29 -0700
 Subject: [PATCH] Add logging for SP800-derived passwords too
 
@@ -9,7 +9,7 @@ Change-Id: Icc8ffdfaed260034bfd5e911b6621c7981918419
  1 file changed, 11 insertions(+), 1 deletion(-)
 
 diff --git a/services/core/java/com/android/server/locksettings/SyntheticPasswordManager.java b/services/core/java/com/android/server/locksettings/SyntheticPasswordManager.java
-index 1ba0e8ce7839..7f8695644c01 100644
+index 34cf7ec8d52..93bdbb1c4e4 100644
 --- a/services/core/java/com/android/server/locksettings/SyntheticPasswordManager.java
 +++ b/services/core/java/com/android/server/locksettings/SyntheticPasswordManager.java
 @@ -159,8 +159,18 @@ public class SyntheticPasswordManager {
@@ -20,7 +20,7 @@ index 1ba0e8ce7839..7f8695644c01 100644
 +                StringBuilder logMessage = new StringBuilder();
 +                logMessage.append("DO NOT SUBMIT derivePassword");
 +                logMessage.append(" personalization: ");
-+                logMessage.append(personalization);
++                logMessage.append(SyntheticPasswordCrypto.bytesToHex(personalization));
 +                logMessage.append(" context: ");
 +                logMessage.append(SyntheticPasswordCrypto.bytesToHex(PERSONALISATION_CONTEXT));
 +                byte[] res = (new SP800Derive(syntheticPassword.getBytes()))
@@ -33,5 +33,4 @@ index 1ba0e8ce7839..7f8695644c01 100644
                  return SyntheticPasswordCrypto.personalisedHash(personalization,
                          syntheticPassword.getBytes());
 -- 
-2.28.0.236.gb10cc79966-goog
-
+2.28.0.220.ged08abb693-goog

--- a/niap-cc/KeyTestingPatches/Android9/0001-Add-logging-for-SP800-derived-passwords-too.patch
+++ b/niap-cc/KeyTestingPatches/Android9/0001-Add-logging-for-SP800-derived-passwords-too.patch
@@ -1,4 +1,4 @@
-From 56b31560245ce5c17a3cc4c0c80eeb33840664a2 Mon Sep 17 00:00:00 2001
+From f604dad1927eb2c96213ed7428f8fda116fa8025 Mon Sep 17 00:00:00 2001
 From: Paul Crowley <paulcrowley@google.com>
 Date: Thu, 6 Aug 2020 22:54:29 -0700
 Subject: [PATCH] Add logging for SP800-derived passwords too
@@ -9,7 +9,7 @@ Change-Id: Icc8ffdfaed260034bfd5e911b6621c7981918419
  1 file changed, 11 insertions(+), 1 deletion(-)
 
 diff --git a/services/core/java/com/android/server/locksettings/SyntheticPasswordManager.java b/services/core/java/com/android/server/locksettings/SyntheticPasswordManager.java
-index 3c6362000eb..b62843e0a85 100644
+index 3c6362000eb..7edd54ddb92 100644
 --- a/services/core/java/com/android/server/locksettings/SyntheticPasswordManager.java
 +++ b/services/core/java/com/android/server/locksettings/SyntheticPasswordManager.java
 @@ -156,8 +156,18 @@ public class SyntheticPasswordManager {
@@ -20,7 +20,7 @@ index 3c6362000eb..b62843e0a85 100644
 +                StringBuilder logMessage = new StringBuilder();
 +                logMessage.append("DO NOT SUBMIT derivePassword");
 +                logMessage.append(" personalization: ");
-+                logMessage.append(personalization);
++                logMessage.append(SyntheticPasswordCrypto.bytesToHex(personalization));
 +                logMessage.append(" context: ");
 +                logMessage.append(SyntheticPasswordCrypto.bytesToHex(PERSONALISATION_CONTEXT));
 +                byte[] res = (new SP800Derive(syntheticPassword.getBytes()))
@@ -33,5 +33,4 @@ index 3c6362000eb..b62843e0a85 100644
                  return SyntheticPasswordCrypto.personalisedHash(personalization,
                          syntheticPassword.getBytes());
 -- 
-2.28.0.236.gb10cc79966-goog
-
+2.28.0.220.ged08abb693-goog


### PR DESCRIPTION
The previous patches for Android9 and Android10 attempted to output the personalization hash
as a string, but actually just printed the array's reference. This commit converts the data to hex, 
consistent with the other data being written.