### PR TITLE
Using worker thread to avoid ANR

### DIFF
--- a/ioXt/uraniborg/AndroidStudioProject/Hubble/app/build.gradle
+++ b/ioXt/uraniborg/AndroidStudioProject/Hubble/app/build.gradle
@@ -17,6 +17,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {

--- a/ioXt/uraniborg/AndroidStudioProject/Hubble/app/src/main/res/layout/activity_main.xml
+++ b/ioXt/uraniborg/AndroidStudioProject/Hubble/app/src/main/res/layout/activity_main.xml
@@ -7,6 +7,7 @@
     tools:context=".MainActivity">
 
     <TextView
+        android:id="@+id/textView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Hello World!"

--- a/ioXt/uraniborg/AndroidStudioProject/Hubble/app/src/main/res/values/strings.xml
+++ b/ioXt/uraniborg/AndroidStudioProject/Hubble/app/src/main/res/values/strings.xml
@@ -3,4 +3,6 @@
     <string name="app_description">An app that queries the system and collects data about
         preloaded apps on the system, and also about APK signing information, permissions,
         and other device info.</string>
+    <string name="scan_start">Scanning...</string>
+    <string name="scan_end">Scan complete</string>
 </resources>


### PR DESCRIPTION
Hubble uses the Ui thread to do all the tasks (get* and write*). If
it takes a longer time (more than 5 sec), we may get an ANR error.
It's better to use another thread to do these and we could also have
some status to show on MainActivity.