### PR TITLE
Resolve issues encountered during permission tests

### DIFF
--- a/niap-cc/Permissions/Tester/app/src/main/AndroidManifest.xml
+++ b/niap-cc/Permissions/Tester/app/src/main/AndroidManifest.xml
@@ -44,6 +44,7 @@
             android:permission="android.permission.BIND_TELECOM_CONNECTION_SERVICE" />
 
     </application>
+
     <uses-permission android:name="android.permission.ACCESS_LOCATION_EXTRA_COMMANDS" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />

--- a/niap-cc/Permissions/Tester/app/src/main/java/com/android/certifications/niap/permissions/Constants.java
+++ b/niap-cc/Permissions/Tester/app/src/main/java/com/android/certifications/niap/permissions/Constants.java
@@ -73,7 +73,7 @@ public class Constants {
      * used for the BIND permission tests and sets up the environment for a number of other tests
      * run by this app.
      */
-    public static final String COMPANION_PACKAGE = "com.google.permissions.tester.companion";
+    public static final String COMPANION_PACKAGE = "com.android.certifications.niap.permissions.companion";
     /**
      * The name of the Google Play Services package.
      */

--- a/niap-cc/Permissions/Tester/app/src/main/java/com/android/certifications/niap/permissions/SignaturePermissionTester.java
+++ b/niap-cc/Permissions/Tester/app/src/main/java/com/android/certifications/niap/permissions/SignaturePermissionTester.java
@@ -1762,8 +1762,6 @@ public class SignaturePermissionTester extends BasePermissionTester {
 
         mPermissionTasks.put(permission.WRITE_SECURE_SETTINGS,
                 new PermissionTest(false, () -> {
-                    // mTransacts.invokeTransact(TransactIds.WINDOW_SERVICE, TransactIds.WINDOW_DESCRIPTOR, 8,
-                    // 1, 1080, 2160);
                     Settings.Secure.putString(mContentResolver, "TEST_KEY", "TEST_VALUE");
                 }));
 

--- a/niap-cc/Permissions/Tester/app/src/main/java/com/android/certifications/niap/permissions/utils/Transacts.java
+++ b/niap-cc/Permissions/Tester/app/src/main/java/com/android/certifications/niap/permissions/utils/Transacts.java
@@ -402,7 +402,7 @@ public class Transacts {
      * Initializes the mapping of transact names to their expected IDs for a device running Android
      * 9 / API level 28.
      */
-    public class PTransacts extends Transacts {
+    private static class PTransacts extends Transacts {
         public PTransacts() {
             super();
             mDeviceApiLevel = Build.VERSION_CODES.P;
@@ -520,24 +520,27 @@ public class Transacts {
             mDescriptorTransacts.put(NETWORK_MANAGEMENT_DESCRIPTOR, transactIds);
 
             transactIds = new HashMap<>();
-            transactIds.put(unhandledBack, 7);
-            transactIds.put(inputDispatchingTimedOut, 159);
             transactIds.put(bindBackupAgent, 88);
-            transactIds.put(setFrontActivityScreenCompatMode, 123);
             transactIds.put(performIdleMaintenance, 180);
-            transactIds.put(startActivityFromRecents, 198);
             transactIds.put(setDumpHeapDebugLimit, 225);
             transactIds.put(updateLockTaskPackages, 228);
             transactIds.put(getGrantedUriPermissions, 263);
             transactIds.put(setHasTopUi, 285);
-            transactIds.put(releasePersistableUriPermission, 182);
             transactIds.put(dismissKeyguard, 289);
-            transactIds.put(requestBugReport, 156);
             transactIds.put(resumeAppSwitches, 87);
             transactIds.put(getContentProviderExternal, 138);
             transactIds.put(getIntentForIntentSender, 161);
-            transactIds.put(getFrontActivityScreenCompatMode, 122);
+            transactIds.put(getTaskDescription, 80);
             transactIds.put(getAssistContextExtras, 162);
+            transactIds.put(unhandledBack, 7);
+            transactIds.put(inputDispatchingTimedOut, 159);
+            transactIds.put(setFrontActivityScreenCompatMode, 123);
+            transactIds.put(setAlwaysFinish, 38);
+            transactIds.put(startActivityFromRecents, 198);
+            transactIds.put(releasePersistableUriPermission, 182);
+            transactIds.put(requestBugReport, 156);
+            transactIds.put(getFrontActivityScreenCompatMode, 122);
+            transactIds.put(setProcessLimit, 47);
             transactIds.put(signalPersistentProcesses, 55);
             transactIds.put(updateConfiguration, 43);
             transactIds.put(appNotRespondingViaProvider, 184);
@@ -570,8 +573,8 @@ public class Transacts {
             mDescriptorTransacts.put(WINDOW_DESCRIPTOR, transactIds);
 
             transactIds = new HashMap<>();
-            transactIds.put(noteOperation, 2);
             transactIds.put(setUserRestriction, 20);
+            transactIds.put(noteOperation, 2);
             mDescriptorTransacts.put(APP_OPS_DESCRIPTOR, transactIds);
 
             transactIds = new HashMap<>();
@@ -582,12 +585,12 @@ public class Transacts {
             mDescriptorTransacts.put(ACCESSIBILITY_DESCRIPTOR, transactIds);
 
             transactIds = new HashMap<>();
-            transactIds.put(setBackupEnabled, 7);
-            mDescriptorTransacts.put(BACKUP_DESCRIPTOR, transactIds);
-
-            transactIds = new HashMap<>();
             transactIds.put(setBindAppWidgetPermission, 20);
             mDescriptorTransacts.put(APPWIDGET_DESCRIPTOR, transactIds);
+
+            transactIds = new HashMap<>();
+            transactIds.put(setBackupEnabled, 7);
+            mDescriptorTransacts.put(BACKUP_DESCRIPTOR, transactIds);
 
             transactIds = new HashMap<>();
             transactIds.put(reportEnabledTrustAgentsChanged, 3);
@@ -644,7 +647,7 @@ public class Transacts {
      * Initializes the mapping of transact names to their expected IDs for a device running Android
      * 10 / API level 29.
      */
-    private class QTransacts extends Transacts {
+    private static class QTransacts extends Transacts {
         public QTransacts() {
             super();
             mDeviceApiLevel = Build.VERSION_CODES.Q;
@@ -923,7 +926,7 @@ public class Transacts {
      * Initializes the mapping of transact names to their expected IDs for a device running Android
      * 11 / API level 30.
      */
-    public class RTransacts extends Transacts {
+    private static class RTransacts extends Transacts {
         public RTransacts() {
             super();
             mDeviceApiLevel = Build.VERSION_CODES.R;
@@ -1222,11 +1225,11 @@ public class Transacts {
             // class created by the app under the TransactIds/ directory. This will allow the tester
             // to use the specific transact IDs for the device under test.
             case Build.VERSION_CODES.P:
-                return new Transacts().new PTransacts();
+                return new PTransacts();
             case Build.VERSION_CODES.Q:
-                return new Transacts().new QTransacts();
+                return new QTransacts();
             case Build.VERSION_CODES.R:
-                return new Transacts().new RTransacts();
+                return new RTransacts();
             default:
                 throw new IllegalArgumentException(
                         "The provided API level, " + apiLevel + ", is not supported");

--- a/niap-cc/Permissions/Tester/query_permissions.sh
+++ b/niap-cc/Permissions/Tester/query_permissions.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Copyright 2020 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Queries for all non-platform permissions on the device and outputs a
+# list of uses-permissions tags that can be added to the AndroidManifest
+# to be used during the non-platform permission tests.
+#
+# Input:
+# [$1] - the serial of the device on which to run the command; this is only
+#         required if multiple devices are connected to the system
+
+serial=""
+if [[ -n $1 ]]; then
+    serial="-s $1"
+fi
+permission=""
+adb $serial shell pm list permissions -f -g | while read line
+do
+    if echo $line | grep -q '+ permission'; then
+        permission=$(echo $line | awk -F: '{print $NF}')
+    fi
+    if echo $line | grep -q 'package:'; then
+        package=$(echo $line | awk -F: '{print $NF}')
+        if [[ "$package" != "android" ]] && [[ -n $permission ]]; then
+            echo "<uses-permission android:name=\"$permission\" />"
+            permission=""
+        fi
+    fi
+done

--- a/niap-cc/Permissions/TransactIds/app/src/main/java/com/android/certifications/niap/permissions/transactids/MainActivity.java
+++ b/niap-cc/Permissions/TransactIds/app/src/main/java/com/android/certifications/niap/permissions/transactids/MainActivity.java
@@ -146,6 +146,8 @@ public class MainActivity extends AppCompatActivity {
                     descriptorTransacts);
             queryTransactId(Transacts.ACTIVITY_DESCRIPTOR, Transacts.getIntentForIntentSender,
                     descriptorTransacts);
+            queryTransactId(Transacts.ACTIVITY_DESCRIPTOR, Transacts.getTaskDescription,
+                    descriptorTransacts);
             queryTransactId(Transacts.ACTIVITY_DESCRIPTOR, Transacts.inputDispatchingTimedOut,
                     descriptorTransacts);
             queryTransactId(Transacts.ACTIVITY_DESCRIPTOR, Transacts.performIdleMaintenance,


### PR DESCRIPTION
This commit addresses the following issues:

- Name of the companion package is corrected in Constants
- Companion package skips location setup on non-GMS devices
- Missing transact IDs are added to default Transacts for API 28
- Missing transact is added to transactids for API 28
- query_permissions.sh script is added to produce list of
  uses-permission tags to be used during non-platform tests