### PR TITLE
Add support for new permissions introduced in Android 12

### DIFF
--- a/niap-cc/Permissions/Companion/app/src/main/AndroidManifest.xml
+++ b/niap-cc/Permissions/Companion/app/src/main/AndroidManifest.xml
@@ -367,6 +367,53 @@
             android:enabled="true"
             android:exported="true"
             android:permission="android.permission.BIND_AUGMENTED_AUTOFILL_SERVICE" />
+
+        <!-- The following services are required for new permissions in Android 12. -->
+        <service android:name=".services.TestBindCallDiagnosticServiceService"
+            android:permission="android.permission.BIND_CALL_DIAGNOSTIC_SERVICE"
+            android:enabled="true"
+            android:exported="true" />
+        <service android:name=".services.TestBindCompanionDeviceServiceService"
+            android:permission="android.permission.BIND_COMPANION_DEVICE_SERVICE"
+            android:enabled="true"
+            android:exported="true" />
+        <service android:name=".services.TestBindDisplayHashingServiceService"
+            android:permission="android.permission.BIND_DISPLAY_HASHING_SERVICE"
+            android:enabled="true"
+            android:exported="true" />
+        <service android:name=".services.TestBindDomainVerificationAgentService"
+            android:permission="android.permission.BIND_DOMAIN_VERIFICATION_AGENT"
+            android:enabled="true"
+            android:exported="true" />
+        <service android:name=".services.TestBindGbaServiceService"
+            android:permission="android.permission.BIND_GBA_SERVICE"
+            android:enabled="true"
+            android:exported="true" />
+        <service android:name=".services.TestBindHotwordDetectionServiceService"
+            android:permission="android.permission.BIND_HOTWORD_DETECTION_SERVICE"
+            android:enabled="true"
+            android:exported="true" />
+        <service android:name=".services.TestBindMusicRecognitionServiceService"
+            android:permission="android.permission.BIND_MUSIC_RECOGNITION_SERVICE"
+            android:enabled="true"
+            android:exported="true" />
+        <service android:name=".services.TestBindResumeOnRebootServiceService"
+            android:permission="android.permission.BIND_RESUME_ON_REBOOT_SERVICE"
+            android:enabled="true"
+            android:exported="true" />
+        <service android:name=".services.TestBindRotationResolverServiceService"
+            android:permission="android.permission.BIND_ROTATION_RESOLVER_SERVICE"
+            android:enabled="true"
+            android:exported="true" />
+        <service android:name=".services.TestBindTimeZoneProviderServiceService"
+            android:permission="android.permission.BIND_TIME_ZONE_PROVIDER_SERVICE"
+            android:enabled="true"
+            android:exported="true" />
+        <service android:name=".services.TestBindTranslationServiceService"
+            android:permission="android.permission.BIND_TRANSLATION_SERVICE"
+            android:enabled="true"
+            android:exported="true" />
+
     </application>
 
 </manifest>

--- a/niap-cc/Permissions/Companion/app/src/main/java/com/android/certifications/niap/permissions/companion/MainActivity.java
+++ b/niap-cc/Permissions/Companion/app/src/main/java/com/android/certifications/niap/permissions/companion/MainActivity.java
@@ -82,6 +82,7 @@ public class MainActivity extends AppCompatActivity {
     private TextView mStatusTextView;
     private Button mSetupButton;
     private boolean mGmsAvailable;
+
     /**
      * Used to ensure the GMS location settings are configured as required for the location tests.
      */
@@ -96,7 +97,6 @@ public class MainActivity extends AppCompatActivity {
 
         mGmsAvailable = GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(this)
                 == ConnectionResult.SUCCESS;
-        mGmsAvailable = false;
         if (mGmsAvailable) {
             mLocationRequest = LocationRequest.create().setPriority(
                     LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY).setInterval(1000);

--- a/niap-cc/Permissions/Companion/app/src/main/java/com/android/certifications/niap/permissions/companion/services/TestBindCallDiagnosticServiceService.java
+++ b/niap-cc/Permissions/Companion/app/src/main/java/com/android/certifications/niap/permissions/companion/services/TestBindCallDiagnosticServiceService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.certifications.niap.permissions.companion.services;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+import android.util.Log;
+
+/**
+ * Exported service used to test the BIND_CALL_DIAGNOSTIC_SERVICE permission.
+ *
+ * This service requires clients are granted the BIND_CALL_DIAGNOSTIC_SERVICE
+ * permission to bind to it. The Permission Test Tool can attempt to bind to this service
+ * and invoke the {@link TestBindCallDiagnosticServiceServiceImpl#testMethod()} method
+ * to verify that the platform properly enforces this permission requirement.
+ */
+public class TestBindCallDiagnosticServiceService extends Service {
+    private static final String TAG = "PermissionTesterBindService";
+    private TestBindCallDiagnosticServiceServiceImpl bindService;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        bindService = new TestBindCallDiagnosticServiceServiceImpl();
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return bindService;
+    }
+
+    static class TestBindCallDiagnosticServiceServiceImpl extends TestBindService.Stub {
+        public void testMethod() {
+            Log.d(TAG, "The caller successfully invoked the test method on service "
+                    + "TestBindCallDiagnosticServiceService");
+        }
+    }
+}

--- a/niap-cc/Permissions/Companion/app/src/main/java/com/android/certifications/niap/permissions/companion/services/TestBindCompanionDeviceServiceService.java
+++ b/niap-cc/Permissions/Companion/app/src/main/java/com/android/certifications/niap/permissions/companion/services/TestBindCompanionDeviceServiceService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.certifications.niap.permissions.companion.services;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+import android.util.Log;
+
+/**
+ * Exported service used to test the BIND_COMPANION_DEVICE_SERVICE permission.
+ *
+ * This service requires clients are granted the BIND_COMPANION_DEVICE_SERVICE
+ * permission to bind to it. The Permission Test Tool can attempt to bind to this service
+ * and invoke the {@link TestBindCompanionDeviceServiceServiceImpl#testMethod()} method
+ * to verify that the platform properly enforces this permission requirement.
+ */
+public class TestBindCompanionDeviceServiceService extends Service {
+    private static final String TAG = "PermissionTesterBindService";
+    private TestBindCompanionDeviceServiceServiceImpl bindService;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        bindService = new TestBindCompanionDeviceServiceServiceImpl();
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return bindService;
+    }
+
+    static class TestBindCompanionDeviceServiceServiceImpl extends TestBindService.Stub {
+        public void testMethod() {
+            Log.d(TAG, "The caller successfully invoked the test method on service "
+                    + "TestBindCompanionDeviceServiceService");
+        }
+    }
+}

--- a/niap-cc/Permissions/Companion/app/src/main/java/com/android/certifications/niap/permissions/companion/services/TestBindDisplayHashingServiceService.java
+++ b/niap-cc/Permissions/Companion/app/src/main/java/com/android/certifications/niap/permissions/companion/services/TestBindDisplayHashingServiceService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.certifications.niap.permissions.companion.services;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+import android.util.Log;
+
+/**
+ * Exported service used to test the BIND_DISPLAY_HASHING_SERVICE permission.
+ *
+ * This service requires clients are granted the BIND_DISPLAY_HASHING_SERVICE
+ * permission to bind to it. The Permission Test Tool can attempt to bind to this service
+ * and invoke the {@link TestBindDisplayHashingServiceServiceImpl#testMethod()} method
+ * to verify that the platform properly enforces this permission requirement.
+ */
+public class TestBindDisplayHashingServiceService extends Service {
+    private static final String TAG = "PermissionTesterBindService";
+    private TestBindDisplayHashingServiceServiceImpl bindService;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        bindService = new TestBindDisplayHashingServiceServiceImpl();
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return bindService;
+    }
+
+    static class TestBindDisplayHashingServiceServiceImpl extends TestBindService.Stub {
+        public void testMethod() {
+            Log.d(TAG, "The caller successfully invoked the test method on service "
+                    + "TestBindDisplayHashingServiceService");
+        }
+    }
+}

--- a/niap-cc/Permissions/Companion/app/src/main/java/com/android/certifications/niap/permissions/companion/services/TestBindDomainVerificationAgentService.java
+++ b/niap-cc/Permissions/Companion/app/src/main/java/com/android/certifications/niap/permissions/companion/services/TestBindDomainVerificationAgentService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.certifications.niap.permissions.companion.services;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+import android.util.Log;
+
+/**
+ * Exported service used to test the BIND_DOMAIN_VERIFICATION_AGENT permission.
+ *
+ * This service requires clients are granted the BIND_DOMAIN_VERIFICATION_AGENT
+ * permission to bind to it. The Permission Test Tool can attempt to bind to this service
+ * and invoke the {@link TestBindDomainVerificationAgentServiceImpl#testMethod()} method
+ * to verify that the platform properly enforces this permission requirement.
+ */
+public class TestBindDomainVerificationAgentService extends Service {
+    private static final String TAG = "PermissionTesterBindService";
+    private TestBindDomainVerificationAgentServiceImpl bindService;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        bindService = new TestBindDomainVerificationAgentServiceImpl();
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return bindService;
+    }
+
+    static class TestBindDomainVerificationAgentServiceImpl extends TestBindService.Stub {
+        public void testMethod() {
+            Log.d(TAG, "The caller successfully invoked the test method on service "
+                    + "TestBindDomainVerificationAgentService");
+        }
+    }
+}

--- a/niap-cc/Permissions/Companion/app/src/main/java/com/android/certifications/niap/permissions/companion/services/TestBindGbaServiceService.java
+++ b/niap-cc/Permissions/Companion/app/src/main/java/com/android/certifications/niap/permissions/companion/services/TestBindGbaServiceService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.certifications.niap.permissions.companion.services;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+import android.util.Log;
+
+/**
+ * Exported service used to test the BIND_GBA_SERVICE permission.
+ *
+ * This service requires clients are granted the BIND_GBA_SERVICE
+ * permission to bind to it. The Permission Test Tool can attempt to bind to this service
+ * and invoke the {@link TestBindGbaServiceServiceImpl#testMethod()} method
+ * to verify that the platform properly enforces this permission requirement.
+ */
+public class TestBindGbaServiceService extends Service {
+    private static final String TAG = "PermissionTesterBindService";
+    private TestBindGbaServiceServiceImpl bindService;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        bindService = new TestBindGbaServiceServiceImpl();
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return bindService;
+    }
+
+    static class TestBindGbaServiceServiceImpl extends TestBindService.Stub {
+        public void testMethod() {
+            Log.d(TAG, "The caller successfully invoked the test method on service "
+                    + "TestBindGbaServiceService");
+        }
+    }
+}

--- a/niap-cc/Permissions/Companion/app/src/main/java/com/android/certifications/niap/permissions/companion/services/TestBindHotwordDetectionServiceService.java
+++ b/niap-cc/Permissions/Companion/app/src/main/java/com/android/certifications/niap/permissions/companion/services/TestBindHotwordDetectionServiceService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.certifications.niap.permissions.companion.services;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+import android.util.Log;
+
+/**
+ * Exported service used to test the BIND_HOTWORD_DETECTION_SERVICE permission.
+ *
+ * This service requires clients are granted the BIND_HOTWORD_DETECTION_SERVICE
+ * permission to bind to it. The Permission Test Tool can attempt to bind to this service
+ * and invoke the {@link TestBindHotwordDetectionServiceServiceImpl#testMethod()} method
+ * to verify that the platform properly enforces this permission requirement.
+ */
+public class TestBindHotwordDetectionServiceService extends Service {
+    private static final String TAG = "PermissionTesterBindService";
+    private TestBindHotwordDetectionServiceServiceImpl bindService;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        bindService = new TestBindHotwordDetectionServiceServiceImpl();
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return bindService;
+    }
+
+    static class TestBindHotwordDetectionServiceServiceImpl extends TestBindService.Stub {
+        public void testMethod() {
+            Log.d(TAG, "The caller successfully invoked the test method on service "
+                    + "TestBindHotwordDetectionServiceService");
+        }
+    }
+}

--- a/niap-cc/Permissions/Companion/app/src/main/java/com/android/certifications/niap/permissions/companion/services/TestBindMusicRecognitionServiceService.java
+++ b/niap-cc/Permissions/Companion/app/src/main/java/com/android/certifications/niap/permissions/companion/services/TestBindMusicRecognitionServiceService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.certifications.niap.permissions.companion.services;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+import android.util.Log;
+
+/**
+ * Exported service used to test the BIND_MUSIC_RECOGNITION_SERVICE permission.
+ *
+ * This service requires clients are granted the BIND_MUSIC_RECOGNITION_SERVICE
+ * permission to bind to it. The Permission Test Tool can attempt to bind to this service
+ * and invoke the {@link TestBindMusicRecognitionServiceServiceImpl#testMethod()} method
+ * to verify that the platform properly enforces this permission requirement.
+ */
+public class TestBindMusicRecognitionServiceService extends Service {
+    private static final String TAG = "PermissionTesterBindService";
+    private TestBindMusicRecognitionServiceServiceImpl bindService;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        bindService = new TestBindMusicRecognitionServiceServiceImpl();
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return bindService;
+    }
+
+    static class TestBindMusicRecognitionServiceServiceImpl extends TestBindService.Stub {
+        public void testMethod() {
+            Log.d(TAG, "The caller successfully invoked the test method on service "
+                    + "TestBindMusicRecognitionServiceService");
+        }
+    }
+}

--- a/niap-cc/Permissions/Companion/app/src/main/java/com/android/certifications/niap/permissions/companion/services/TestBindResumeOnRebootServiceService.java
+++ b/niap-cc/Permissions/Companion/app/src/main/java/com/android/certifications/niap/permissions/companion/services/TestBindResumeOnRebootServiceService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.certifications.niap.permissions.companion.services;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+import android.util.Log;
+
+/**
+ * Exported service used to test the BIND_RESUME_ON_REBOOT_SERVICE permission.
+ *
+ * This service requires clients are granted the BIND_RESUME_ON_REBOOT_SERVICE
+ * permission to bind to it. The Permission Test Tool can attempt to bind to this service
+ * and invoke the {@link TestBindResumeOnRebootServiceServiceImpl#testMethod()} method
+ * to verify that the platform properly enforces this permission requirement.
+ */
+public class TestBindResumeOnRebootServiceService extends Service {
+    private static final String TAG = "PermissionTesterBindService";
+    private TestBindResumeOnRebootServiceServiceImpl bindService;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        bindService = new TestBindResumeOnRebootServiceServiceImpl();
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return bindService;
+    }
+
+    static class TestBindResumeOnRebootServiceServiceImpl extends TestBindService.Stub {
+        public void testMethod() {
+            Log.d(TAG, "The caller successfully invoked the test method on service "
+                    + "TestBindResumeOnRebootServiceService");
+        }
+    }
+}

--- a/niap-cc/Permissions/Companion/app/src/main/java/com/android/certifications/niap/permissions/companion/services/TestBindRotationResolverServiceService.java
+++ b/niap-cc/Permissions/Companion/app/src/main/java/com/android/certifications/niap/permissions/companion/services/TestBindRotationResolverServiceService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.certifications.niap.permissions.companion.services;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+import android.util.Log;
+
+/**
+ * Exported service used to test the BIND_ROTATION_RESOLVER_SERVICE permission.
+ *
+ * This service requires clients are granted the BIND_ROTATION_RESOLVER_SERVICE
+ * permission to bind to it. The Permission Test Tool can attempt to bind to this service
+ * and invoke the {@link TestBindRotationResolverServiceServiceImpl#testMethod()} method
+ * to verify that the platform properly enforces this permission requirement.
+ */
+public class TestBindRotationResolverServiceService extends Service {
+    private static final String TAG = "PermissionTesterBindService";
+    private TestBindRotationResolverServiceServiceImpl bindService;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        bindService = new TestBindRotationResolverServiceServiceImpl();
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return bindService;
+    }
+
+    static class TestBindRotationResolverServiceServiceImpl extends TestBindService.Stub {
+        public void testMethod() {
+            Log.d(TAG, "The caller successfully invoked the test method on service "
+                    + "TestBindRotationResolverServiceService");
+        }
+    }
+}

--- a/niap-cc/Permissions/Companion/app/src/main/java/com/android/certifications/niap/permissions/companion/services/TestBindTimeZoneProviderServiceService.java
+++ b/niap-cc/Permissions/Companion/app/src/main/java/com/android/certifications/niap/permissions/companion/services/TestBindTimeZoneProviderServiceService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.certifications.niap.permissions.companion.services;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+import android.util.Log;
+
+/**
+ * Exported service used to test the BIND_TIME_ZONE_PROVIDER_SERVICE permission.
+ *
+ * This service requires clients are granted the BIND_TIME_ZONE_PROVIDER_SERVICE
+ * permission to bind to it. The Permission Test Tool can attempt to bind to this service
+ * and invoke the {@link TestBindTimeZoneProviderServiceServiceImpl#testMethod()} method
+ * to verify that the platform properly enforces this permission requirement.
+ */
+public class TestBindTimeZoneProviderServiceService extends Service {
+    private static final String TAG = "PermissionTesterBindService";
+    private TestBindTimeZoneProviderServiceServiceImpl bindService;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        bindService = new TestBindTimeZoneProviderServiceServiceImpl();
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return bindService;
+    }
+
+    static class TestBindTimeZoneProviderServiceServiceImpl extends TestBindService.Stub {
+        public void testMethod() {
+            Log.d(TAG, "The caller successfully invoked the test method on service "
+                    + "TestBindTimeZoneProviderServiceService");
+        }
+    }
+}

--- a/niap-cc/Permissions/Companion/app/src/main/java/com/android/certifications/niap/permissions/companion/services/TestBindTranslationServiceService.java
+++ b/niap-cc/Permissions/Companion/app/src/main/java/com/android/certifications/niap/permissions/companion/services/TestBindTranslationServiceService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.certifications.niap.permissions.companion.services;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+import android.util.Log;
+
+/**
+ * Exported service used to test the BIND_TRANSLATION_SERVICE permission.
+ *
+ * This service requires clients are granted the BIND_TRANSLATION_SERVICE
+ * permission to bind to it. The Permission Test Tool can attempt to bind to this service
+ * and invoke the {@link TestBindTranslationServiceServiceImpl#testMethod()} method
+ * to verify that the platform properly enforces this permission requirement.
+ */
+public class TestBindTranslationServiceService extends Service {
+    private static final String TAG = "PermissionTesterBindService";
+    private TestBindTranslationServiceServiceImpl bindService;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        bindService = new TestBindTranslationServiceServiceImpl();
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return bindService;
+    }
+
+    static class TestBindTranslationServiceServiceImpl extends TestBindService.Stub {
+        public void testMethod() {
+            Log.d(TAG, "The caller successfully invoked the test method on service "
+                    + "TestBindTranslationServiceService");
+        }
+    }
+}

--- a/niap-cc/Permissions/Tester/README.md
+++ b/niap-cc/Permissions/Tester/README.md
@@ -17,7 +17,7 @@ run these tests.
 The `BasePermissionTester` class is the base abstract class from which all other
 permission testers derive. This class contains an inner `PermissionTester`
 utility class that is comprised of a `Runnable` that can be used to verify the
-API, resources, etc., guarded by the permission behave as expeced, along with a
+API, resources, etc., guarded by the permission behave as expected, along with a
 minimum and maximum API level. Subclasses only need to override the
 `runPermissionTests` method to iterate through all permissions to be tested,
 utilizing the `BasePermissionTester#runPermissionTest(permission,
@@ -37,6 +37,28 @@ defined a new instance can be instantiated and returned in the `List` in
 `GmsPermissionConfiguration` and `DebugConfiguration`. During development
 the `DebugConfiguration` can be used by returning the new tester / permission
 under test and modifying `Constants.USE_DEBUG_CONFIG` to `true`.
+
+## Internal Permissions
+Android 12 introduced a new `internal` protection level for permissions that are
+only granted to requesting apps that satisfy one of the other protection flags
+declared for the permission (for a full list of protection flags, see
+[protectionLevel]
+(https://developer.android.com/reference/android/R.attr#protectionLevel)). Since
+`internal` permissions are not granted to apps signed with the platform's
+signing key, the granted path cannot be verified using the standard permission
+tester APK. However, a number of these permissions are granted to the `shell`
+user, and instrumentation tests allow a test to run as the `shell` user by
+invoking [`adoptShellPermissionIdentity`]
+(https://developer.android.com/reference/android/app/UiAutomation#adoptShellPermissionIdentity()).
+This app contains an instrumentation test, `InternalPermissionsTest` under
+`androidTest/` that can be used to verify the APIs guarded by the `internal`
+permissions behave as expected when the permission is granted.
+
+The instrumentation test APK can be built by running `gradlew
+connectedAndroidTest` from the command line within the `Tester/` directory;
+this should generate `app-debug-androidTest.apk`. This APK should be signed with
+the same signing key used to sign the permission tester APK to ensure the
+instrumentation tests can be run against this app.
 
 ## Companion Package
 Under the `Companion/` directory exists the project for the tester companion

--- a/niap-cc/Permissions/Tester/app/build.gradle
+++ b/niap-cc/Permissions/Tester/app/build.gradle
@@ -23,11 +23,11 @@ android {
         release {
         }
     }
-    compileSdkVersion 30
+    compileSdkVersion 31
     defaultConfig {
         applicationId "com.android.certifications.niap.permissions"
         minSdkVersion 28
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -54,10 +54,13 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:runner:1.1.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
     implementation 'com.google.android.gms:play-services-location:17.0.0'
     implementation 'com.google.android.gms:play-services-vision:20.1.0'
     implementation 'com.google.android.gms:play-services-base:17.3.0'
+
+    androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test:runner:1.1.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
+    androidTestImplementation 'androidx.test:rules:1.1.0'
 }

--- a/niap-cc/Permissions/Tester/app/src/androidTest/AndroidManifest.xml
+++ b/niap-cc/Permissions/Tester/app/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ Copyright 2021 The Android Open Source Project
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.certifications.niap.permissions.test" >
+
+    <uses-sdk
+        android:minSdkVersion="28"
+        android:targetSdkVersion="31" />
+
+    <instrumentation
+        android:name="androidx.test.runner.AndroidJUnitRunner"
+        android:functionalTest="false"
+        android:handleProfiling="false"
+        android:label="Tests for com.android.certifications.niap.permissions"
+        android:targetPackage="com.android.certifications.niap.permissions" />
+
+    <uses-permission android:name="android.permission.REORDER_TASKS" />
+
+    <application
+        android:debuggable="true"
+        android:extractNativeLibs="false" >
+        <uses-library android:name="android.test.runner" />
+
+        <activity
+            android:name="androidx.test.core.app.InstrumentationActivityInvoker$BootstrapActivity"
+            android:exported="false"
+            android:theme="@android:style/Theme" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+            </intent-filter>
+        </activity>
+        <activity
+            android:name="androidx.test.core.app.InstrumentationActivityInvoker$EmptyActivity"
+            android:exported="false"
+            android:theme="@android:style/Theme" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+            </intent-filter>
+        </activity>
+        <activity
+            android:name="androidx.test.core.app.InstrumentationActivityInvoker$EmptyFloatingActivity"
+            android:exported="false"
+            android:theme="@android:style/Theme.Dialog" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>
+

--- a/niap-cc/Permissions/Tester/app/src/androidTest/java/com/android/certifications/niap/permissions/InternalPermissionsTest.java
+++ b/niap-cc/Permissions/Tester/app/src/androidTest/java/com/android/certifications/niap/permissions/InternalPermissionsTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.certifications.niap.permissions;
+
+import static com.android.certifications.niap.permissions.utils.InternalPermissions.permission;
+
+import static org.junit.Assert.assertTrue;
+
+import android.app.Activity;
+import android.app.UiAutomation;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.rule.ActivityTestRule;
+
+import com.android.certifications.niap.permissions.activities.MainActivity;
+import com.android.certifications.niap.permissions.config.TestConfiguration;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Instrumentation test to verify internal protection level permissions properly grant access to
+ * their API, resources, etc., when the corresponding permission is granted. Internal
+ * permissions are not granted to apps signed with the platform's signing key, but many are granted
+ * to the shell user. Since instrumentation tests allow adopting the shell permission identity,
+ * this test class can adopt this identity to be granted these permissions and verify the platform
+ * behavior.
+ */
+@RunWith(AndroidJUnit4.class)
+public class InternalPermissionsTest {
+    /**
+     * A list of permissions that can be granted to the shell identity.
+     */
+    private static List<String> mPermissions;
+    static {
+        mPermissions = new ArrayList<>();
+        mPermissions.add(permission.MANAGE_HOTWORD_DETECTION);
+        mPermissions.add(permission.OBSERVE_SENSOR_PRIVACY);
+        mPermissions.add(permission.ACCESS_RCS_USER_CAPABILITY_EXCHANGE);
+        mPermissions.add(permission.BYPASS_ROLE_QUALIFICATION);
+        mPermissions.add(permission.PERFORM_IMS_SINGLE_REGISTRATION);
+    }
+
+    private UiAutomation mUiAutomation;
+
+    @Rule
+    public ActivityTestRule<MainActivity> rule = new ActivityTestRule<>(MainActivity.class, false,
+            true);
+
+    @Before
+    public void setUp() {
+        mUiAutomation = InstrumentationRegistry.getInstrumentation().getUiAutomation();
+    }
+
+    @After
+    public void tearDown() {
+        mUiAutomation.dropShellPermissionIdentity();
+    }
+
+    @Test
+    public void runPermissionTests_shellIdentity_apisSuccessful() throws Exception {
+        InternalPermissionTester permissionTester = new InternalPermissionTester(
+                new InternalTestConfiguration(mPermissions), rule.getActivity());
+        mUiAutomation.adoptShellPermissionIdentity();
+
+        assertTrue(permissionTester.runPermissionTests());
+    }
+
+    public static class InternalTestConfiguration implements TestConfiguration {
+        private Optional<List<String>> mPermissions;
+
+        public InternalTestConfiguration(List<String> permissions) {
+            mPermissions = Optional.of(permissions);
+        }
+
+        @Override
+        public List<BasePermissionTester> getPermissionTesters(Activity activity) {
+            List<BasePermissionTester> permissionTesters = new ArrayList<>();
+            permissionTesters.add(new InternalPermissionTester(this, activity));
+            return permissionTesters;
+        }
+
+        @Override
+        public Optional<List<String>> getInternalPermissions() {
+            return mPermissions;
+        }
+
+        @Override
+        public int getButtonTextId() {
+            return R.string.run_platform_tests;
+        }
+    }
+}

--- a/niap-cc/Permissions/Tester/app/src/main/AndroidManifest.xml
+++ b/niap-cc/Permissions/Tester/app/src/main/AndroidManifest.xml
@@ -30,7 +30,8 @@
             android:launchMode="singleTop" />
         <activity
             android:name=".activities.MainActivity"
-            android:launchMode="singleTop">
+            android:launchMode="singleTop"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -44,6 +45,9 @@
             android:permission="android.permission.BIND_TELECOM_CONNECTION_SERVICE" />
 
     </application>
+
+    <uses-feature android:name="android.software.companion_device_setup"
+        android:required="false" />
 
     <uses-permission android:name="android.permission.ACCESS_LOCATION_EXTRA_COMMANDS" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -648,6 +652,113 @@
     <uses-permission android:name="android.permission.WHITELIST_AUTO_REVOKE_PERMISSIONS" />
     <uses-permission android:name="com.android.permission.USE_INSTALLER_V2" />
 
+    <!-- New permissions for Android 12 -->
+    <uses-permission android:name="android.permission.HIDE_OVERLAY_WINDOWS" />
+    <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS" />
+    <uses-permission android:name="android.permission.REQUEST_COMPANION_PROFILE_WATCH" />
+    <uses-permission android:name="android.permission.REQUEST_OBSERVE_COMPANION_DEVICE_PRESENCE" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.UWB_RANGING" />
+
+    <uses-permission android:name="android.permission.ACCESS_BLOBS_ACROSS_USERS" />
+    <uses-permission android:name="android.permission.ACCESS_TUNED_INFO" />
+    <uses-permission android:name="android.permission.ADD_TRUSTED_DISPLAY" />
+    <uses-permission android:name="android.permission.ASSOCIATE_INPUT_DEVICE_TO_DISPLAY" />
+    <uses-permission android:name="android.permission.BATTERY_PREDICTION" />
+    <uses-permission android:name="android.permission.BIND_CALL_DIAGNOSTIC_SERVICE" />
+    <uses-permission android:name="android.permission.BIND_COMPANION_DEVICE_SERVICE" />
+    <uses-permission android:name="android.permission.BIND_DISPLAY_HASHING_SERVICE" />
+    <uses-permission android:name="android.permission.BIND_DOMAIN_VERIFICATION_AGENT" />
+    <uses-permission android:name="android.permission.BIND_GBA_SERVICE" />
+    <uses-permission android:name="android.permission.BIND_HOTWORD_DETECTION_SERVICE" />
+    <uses-permission android:name="android.permission.BIND_MUSIC_RECOGNITION_SERVICE" />
+    <uses-permission android:name="android.permission.BIND_RESUME_ON_REBOOT_SERVICE" />
+    <uses-permission android:name="android.permission.BIND_ROTATION_RESOLVER_SERVICE" />
+    <uses-permission android:name="android.permission.BIND_TIME_ZONE_PROVIDER_SERVICE" />
+    <uses-permission android:name="android.permission.BIND_TRANSLATION_SERVICE" />
+    <uses-permission android:name="android.permission.BROADCAST_CLOSE_SYSTEM_DIALOGS" />
+    <uses-permission android:name="android.permission.CAMERA_INJECT_EXTERNAL_CAMERA" />
+    <uses-permission android:name="android.permission.CAPTURE_BLACKOUT_CONTENT" />
+    <uses-permission android:name="android.permission.CAPTURE_TUNER_AUDIO_INPUT" />
+    <uses-permission android:name="android.permission.CLEAR_FREEZE_PERIOD" />
+    <uses-permission android:name="android.permission.CONTROL_DEVICE_STATE" />
+    <uses-permission android:name="android.permission.CONTROL_OEM_PAID_NETWORK_PREFERENCE" />
+    <uses-permission android:name="android.permission.CONTROL_UI_TRACING" />
+    <uses-permission android:name="android.permission.DISABLE_SYSTEM_SOUND_EFFECTS" />
+    <uses-permission android:name="android.permission.FORCE_DEVICE_POLICY_MANAGER_LOGS" />
+    <uses-permission android:name="android.permission.GET_PEOPLE_TILE_PREVIEW" />
+    <uses-permission android:name="android.permission.GET_RUNTIME_PERMISSION_GROUP_MAPPING" />
+    <uses-permission android:name="android.permission.INPUT_CONSUMER" />
+    <uses-permission android:name="android.permission.INSTALL_LOCATION_TIME_ZONE_PROVIDER_SERVICE" />
+    <uses-permission android:name="android.permission.INSTALL_TEST_ONLY_PACKAGE" />
+    <uses-permission android:name="android.permission.KEEP_UNINSTALLED_PACKAGES" />
+    <uses-permission android:name="android.permission.MANAGE_ACTIVITY_TASKS" />
+    <uses-permission android:name="android.permission.MANAGE_APP_HIBERNATION" />
+    <uses-permission android:name="android.permission.MANAGE_CREDENTIAL_MANAGEMENT_APP" />
+    <uses-permission android:name="android.permission.MANAGE_GAME_MODE" />
+    <uses-permission android:name="android.permission.MANAGE_MEDIA" />
+    <uses-permission android:name="android.permission.MANAGE_MEDIA_PROJECTION" />
+    <uses-permission android:name="android.permission.MANAGE_MUSIC_RECOGNITION" />
+    <uses-permission android:name="android.permission.MANAGE_NOTIFICATION_LISTENERS" />
+    <uses-permission android:name="android.permission.MANAGE_ONGOING_CALLS" />
+    <uses-permission android:name="android.permission.MANAGE_ROTATION_RESOLVER" />
+    <uses-permission android:name="android.permission.MANAGE_SEARCH_UI" />
+    <uses-permission android:name="android.permission.MANAGE_SMARTSPACE" />
+    <uses-permission android:name="android.permission.MANAGE_SPEECH_RECOGNITION" />
+    <uses-permission android:name="android.permission.MANAGE_TIME_AND_ZONE_DETECTION" />
+    <uses-permission android:name="android.permission.MANAGE_TOAST_RATE_LIMITING" />
+    <uses-permission android:name="android.permission.MANAGE_UI_TRANSLATION" />
+    <uses-permission android:name="android.permission.MANAGE_WIFI_COUNTRY_CODE" />
+    <uses-permission android:name="android.permission.MODIFY_REFRESH_RATE_SWITCHING_TYPE" />
+    <uses-permission android:name="android.permission.NFC_SET_CONTROLLER_ALWAYS_ON" />
+    <uses-permission android:name="android.permission.OVERRIDE_COMPAT_CHANGE_CONFIG_ON_RELEASE_BUILD" />
+    <uses-permission android:name="android.permission.OVERRIDE_DISPLAY_MODE_REQUESTS" />
+    <uses-permission android:name="android.permission.QUERY_AUDIO_STATE" />
+    <uses-permission android:name="android.permission.READ_DREAM_SUPPRESSION" />
+    <uses-permission android:name="android.permission.READ_NEARBY_STREAMING_POLICY" />
+    <uses-permission android:name="android.permission.READ_PEOPLE_DATA" />
+    <uses-permission android:name="android.permission.READ_PROJECTION_STATE" />
+    <uses-permission android:name="android.permission.REGISTER_MEDIA_RESOURCE_OBSERVER" />
+    <uses-permission android:name="android.permission.RENOUNCE_PERMISSIONS" />
+    <uses-permission android:name="android.permission.RESET_APP_ERRORS" />
+    <uses-permission android:name="android.permission.RESTART_WIFI_SUBSYSTEM" />
+    <uses-permission android:name="android.permission.ROTATE_SURFACE_FLINGER" />
+    <uses-permission android:name="android.permission.SCHEDULE_PRIORITIZED_ALARM" />
+    <uses-permission android:name="android.permission.SEND_CATEGORY_CAR_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.SET_AND_VERIFY_LOCKSCREEN_CREDENTIALS" />
+    <uses-permission android:name="android.permission.SET_CLIP_SOURCE" />
+    <uses-permission android:name="android.permission.SIGNAL_REBOOT_READINESS" />
+    <uses-permission android:name="android.permission.SOUNDTRIGGER_DELEGATE_IDENTITY" />
+    <uses-permission android:name="android.permission.SOUND_TRIGGER_RUN_IN_BATTERY_SAVER" />
+    <uses-permission android:name="android.permission.START_FOREGROUND_SERVICES_FROM_BACKGROUND" />
+    <uses-permission android:name="android.permission.SUGGEST_EXTERNAL_TIME" />
+    <uses-permission android:name="android.permission.SYSTEM_APPLICATION_OVERLAY" />
+    <uses-permission android:name="android.permission.TEST_BIOMETRIC" />
+    <uses-permission android:name="android.permission.TOGGLE_AUTOMOTIVE_PROJECTION" />
+    <uses-permission android:name="android.permission.UNLIMITED_TOASTS" />
+    <uses-permission android:name="android.permission.UPDATE_DOMAIN_VERIFICATION_USER_SELECTION" />
+    <uses-permission android:name="android.permission.UPDATE_FONTS" />
+    <uses-permission android:name="android.permission.USE_ICC_AUTH_WITH_DEVICE_IDENTIFIER" />
+    <uses-permission android:name="android.permission.UWB_PRIVILEGED" />
+    <uses-permission android:name="android.permission.VIRTUAL_INPUT_DEVICE" />
+    <uses-permission android:name="android.permission.WIFI_ACCESS_COEX_UNSAFE_CHANNELS" />
+    <uses-permission android:name="android.permission.WIFI_UPDATE_COEX_UNSAFE_CHANNELS" />
+    <uses-permission android:name="com.android.permission.USE_SYSTEM_DATA_LOADERS" />
+
+    <uses-permission android:name="android.permission.ACCESS_RCS_USER_CAPABILITY_EXCHANGE" />
+    <uses-permission android:name="android.permission.ASSOCIATE_COMPANION_DEVICES" />
+    <uses-permission android:name="android.permission.BACKGROUND_CAMERA" />
+    <uses-permission android:name="android.permission.BYPASS_ROLE_QUALIFICATION" />
+    <uses-permission android:name="android.permission.DOMAIN_VERIFICATION_AGENT" />
+    <uses-permission android:name="android.permission.MANAGE_HOTWORD_DETECTION" />
+    <uses-permission android:name="android.permission.OBSERVE_SENSOR_PRIVACY" />
+    <uses-permission android:name="android.permission.PERFORM_IMS_SINGLE_REGISTRATION" />
+    <uses-permission android:name="android.permission.RECORD_BACKGROUND_AUDIO" />
+
     <!-- The following permissions are added to verify only apps signed by the signing key used to
          sign GMS or the platform are assigned these permissions. -->
     <uses-permission android:name="com.google.android.gms.auth.api.phone.permission.SEND" />
@@ -704,6 +815,12 @@
     <uses-permission android:name="com.google.android.gms.cloudsave.BIND_EVENT_BROADCAST" />
     <uses-permission android:name="com.google.android.gms.WRITE_VERIFY_APPS_CONSENT" />
     <uses-permission android:name="com.google.android.gms.googlehelp.LAUNCH_SUPPORT_SCREENSHARE" />
+
+    <uses-permission android:name="com.android.vending.APP_ERRORS_SERVICE" />
+    <uses-permission android:name="com.google.android.gms.auth.cryptauth.permission.CABLEV2_SERVER_LINK" />
+    <uses-permission android:name="com.google.android.gms.permission.ACTIVITY_RECOGNITION" />
+    <uses-permission android:name="com.google.android.gms.vehicle.permission.SHARED_AUTO_SENSOR_DATA" />
+
 
     <!-- TODO: Additional signature permissions that are declared by the packages preinstalled on
          the device under test should be added here. -->

--- a/niap-cc/Permissions/Tester/app/src/main/aidl/android/security/IKeyChainService.aidl
+++ b/niap-cc/Permissions/Tester/app/src/main/aidl/android/security/IKeyChainService.aidl
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package android.security;
+
+import android.security.AppUriAuthenticationPolicy;
+import android.net.Uri;
+
+import java.util.List;
+
+interface IKeyChainService {
+    // APIs used by KeyChain
+    String requestPrivateKey(String alias);
+    byte[] getCertificate(String alias);
+    byte[] getCaCertificates(String alias);
+    boolean isUserSelectable(String alias);
+    void setUserSelectable(String alias, boolean isUserSelectable);
+
+    int generateKeyPair(in String algorithm, in String /*ParcelableKeyGenParameterSpec*/ spec);
+    boolean setKeyPairCertificate(String alias, in byte[] userCert, in byte[] certChain);
+
+    // APIs used by CertInstaller and DevicePolicyManager
+    String installCaCertificate(in byte[] caCertificate);
+
+    // APIs used by DevicePolicyManager
+    boolean installKeyPair(
+        in byte[] privateKey, in byte[] userCert, in byte[] certChain, String alias, int uid);
+    boolean removeKeyPair(String alias);
+    boolean containsKeyPair(String alias);
+    int[] getGrants(String alias);
+
+    // APIs used by Settings
+    boolean deleteCaCertificate(String alias);
+    boolean reset();
+    String /* StringParceledListSlice */ getUserCaAliases();
+    String /* StringParceledListSlice */ getSystemCaAliases();
+    boolean containsCaAlias(String alias);
+    byte[] getEncodedCaCertificate(String alias, boolean includeDeletedSystem);
+    List<String> getCaCertificateChainAliases(String rootAlias, boolean includeDeletedSystem);
+    void setCredentialManagementApp(String packageName, in AppUriAuthenticationPolicy policy);
+    boolean hasCredentialManagementApp();
+    String getCredentialManagementAppPackageName();
+    AppUriAuthenticationPolicy getCredentialManagementAppPolicy();
+    String getPredefinedAliasForPackageAndUri(String packageName, in Uri uri);
+    void removeCredentialManagementApp();
+    boolean isCredentialManagementApp(String packageName);
+
+    // APIs used by KeyChainActivity
+    // setGrant may fail with value=false when ungrant operation fails in KeyStore.
+    boolean setGrant(int uid, String alias, boolean value);
+    boolean hasGrant(int uid, String alias);
+
+    // API used by Wifi
+    String getWifiKeyGrantAsUser(String alias);
+}

--- a/niap-cc/Permissions/Tester/app/src/main/java/com/android/certifications/niap/permissions/Constants.java
+++ b/niap-cc/Permissions/Tester/app/src/main/java/com/android/certifications/niap/permissions/Constants.java
@@ -75,6 +75,11 @@ public class Constants {
      */
     public static final String COMPANION_PACKAGE = "com.android.certifications.niap.permissions.companion";
     /**
+     * The package name of the app implementing IKeyChainService; this app uses certain signature
+     * level permissions to guard KeyChain operations.
+     */
+    public static final String KEY_CHAIN_PACKAGE = "com.android.keychain";
+    /**
      * The name of the Google Play Services package.
      */
     public static final String GMS_PACKAGE_NAME = "com.google.android.gms";

--- a/niap-cc/Permissions/Tester/app/src/main/java/com/android/certifications/niap/permissions/InternalPermissionTester.java
+++ b/niap-cc/Permissions/Tester/app/src/main/java/com/android/certifications/niap/permissions/InternalPermissionTester.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.certifications.niap.permissions;
+
+import static com.android.certifications.niap.permissions.utils.InternalPermissions.permission;
+
+import android.app.Activity;
+import android.content.pm.PackageManager;
+import android.content.pm.Signature;
+import android.os.Build;
+
+import com.android.certifications.niap.permissions.config.TestConfiguration;
+import com.android.certifications.niap.permissions.log.Logger;
+import com.android.certifications.niap.permissions.log.LoggerFactory;
+import com.android.certifications.niap.permissions.log.StatusLogger;
+import com.android.certifications.niap.permissions.utils.SignatureUtils;
+import com.android.certifications.niap.permissions.utils.Transacts;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Permission tester to verify all platform declared internal permissions properly guard their API,
+ * resources, etc. An internal protection level permission is different from a signature permission
+ * in that the requesting app will not be granted the permission just by being signed with the same
+ * signing key as the platform, but instead must meet other requirements as defined by the
+ * permission's flags.
+ */
+public class InternalPermissionTester extends BasePermissionTester {
+    private static final String TAG = "InternalPermissionTester";
+    private final Logger mLogger = LoggerFactory.createDefaultLogger(TAG);
+
+    /**
+     * Map of internal protection level permissions tto their corresponding {@link
+     * PermissionTest}s.
+     */
+    private final Map<String, BasePermissionTester.PermissionTest> mPermissionTasks;
+
+    public InternalPermissionTester(TestConfiguration configuration, Activity activity) {
+        super(configuration, activity);
+
+        mPermissionTasks = new HashMap<>();
+
+        mPermissionTasks.put(permission.MANAGE_HOTWORD_DETECTION,
+                new PermissionTest(false, Build.VERSION_CODES.S, () -> {
+                    try {
+                        mTransacts.invokeTransact(Transacts.VOICE_INTERACTION_SERVICE,
+                                Transacts.VOICE_INTERACTION_DESCRIPTOR, Transacts.updateState, null,
+                                null, null);
+                    } catch (SecurityException e) {
+                        // Note, there are two places where this transact can throw a
+                        // SecurityException; the first is during the permission check, the second
+                        // is after the permission check is successful when determining if the
+                        // current caller is the VoiceInteractionService. This could be flaky but
+                        // treat the API as successful if the error message indicates the caller
+                        // is not the VoiceInteractionService.
+                        if (!e.getMessage().contains(
+                                "Caller is not the current voice interaction service")) {
+                            throw e;
+                        } else {
+                            mLogger.logDebug(
+                                    "MANAGE_HOTWORD_DETECTION passed permission check, caught the"
+                                            + " following exception: ", e);
+                        }
+                    }
+                }));
+
+        mPermissionTasks.put(permission.OBSERVE_SENSOR_PRIVACY,
+                new PermissionTest(false, Build.VERSION_CODES.S, () -> {
+                    mTransacts.invokeTransact(Transacts.SENSOR_PRIVACY_SERVICE,
+                            Transacts.SENSOR_PRIVACY_DESCRIPTOR, Transacts.isSensorPrivacyEnabled);
+                }));
+
+        mPermissionTasks.put(permission.DOMAIN_VERIFICATION_AGENT,
+                new PermissionTest(false, Build.VERSION_CODES.S, () -> {
+                    mTransacts.invokeTransact(Transacts.DOMAIN_VERIFICATION_SERVICE,
+                            Transacts.DOMAIN_VERIFICATION_DESCRIPTOR,
+                            Transacts.queryValidVerificationPackageNames);
+                }));
+
+        mPermissionTasks.put(permission.ACCESS_RCS_USER_CAPABILITY_EXCHANGE,
+                new PermissionTest(false, Build.VERSION_CODES.S, () -> {
+                    mTransacts.invokeTransact(Transacts.TELEPHONY_IMS_SERVICE,
+                            Transacts.TELEPHONY_IMS_DESCRIPTOR, Transacts.requestAvailability, 0,
+                            mPackageName, null,
+                            null, null);
+                }));
+
+        mPermissionTasks.put(permission.ASSOCIATE_COMPANION_DEVICES,
+                new PermissionTest(false, Build.VERSION_CODES.S, () -> {
+                    Signature signature = SignatureUtils.getTestAppSigningCertificate(mContext);
+                    MessageDigest messageDigest;
+                    try {
+                        messageDigest = MessageDigest.getInstance("SHA-256");
+                    } catch (NoSuchAlgorithmException e) {
+                        throw new UnexpectedPermissionTestFailureException(e);
+                    }
+                    byte[] certDigest = messageDigest.digest(signature.toByteArray());
+                    if (!mPackageManager.hasSigningCertificate(mPackageName, certDigest,
+                            PackageManager.CERT_INPUT_SHA256)) {
+                        throw new UnexpectedPermissionTestFailureException(
+                                "PackageManager reported test app does not have the provided "
+                                        + "signing certificate");
+                    }
+                    mTransacts.invokeTransact(Transacts.COMPANION_DEVICE_SERVICE,
+                            Transacts.COMPANION_DEVICE_DESCRIPTOR, Transacts.createAssociation,
+                            mPackageName, "11:22:33:44:55:66", 0, certDigest);
+                }));
+
+        mPermissionTasks.put(permission.BYPASS_ROLE_QUALIFICATION,
+                new PermissionTest(false, Build.VERSION_CODES.S, () -> {
+                    mTransacts.invokeTransact(Transacts.ROLE_SERVICE, Transacts.ROLE_DESCRIPTOR,
+                            Transacts.setBypassingRoleQualification, false);
+                }));
+
+        mPermissionTasks.put(permission.PERFORM_IMS_SINGLE_REGISTRATION,
+                new PermissionTest(false, Build.VERSION_CODES.S, () -> {
+                    mTransacts.invokeTransact(Transacts.TELEPHONY_IMS_SERVICE,
+                            Transacts.TELEPHONY_IMS_DESCRIPTOR,
+                            Transacts.triggerNetworkRegistration, 0, null, 0, "test-sip-reason");
+                }));
+    }
+
+    @Override
+    public boolean runPermissionTests() {
+        boolean allTestsPassed = true;
+        List<String> permissions = mConfiguration.getInternalPermissions().orElse(
+                new ArrayList<>(mPermissionTasks.keySet()));
+        for (String permission : permissions) {
+            boolean testPassed = runPermissionTest(permission, mPermissionTasks.get(permission),
+                    true);
+            if (!testPassed) {
+                allTestsPassed = false;
+            }
+        }
+        if (allTestsPassed) {
+            StatusLogger.logInfo(
+                    "*** PASSED - all internal permission tests completed successfully");
+        } else {
+            StatusLogger.logInfo(
+                    "!!! FAILED - one or more internal permission tests failed");
+        }
+        return allTestsPassed;
+    }
+}

--- a/niap-cc/Permissions/Tester/app/src/main/java/com/android/certifications/niap/permissions/PrivilegedPermissionTester.java
+++ b/niap-cc/Permissions/Tester/app/src/main/java/com/android/certifications/niap/permissions/PrivilegedPermissionTester.java
@@ -63,7 +63,7 @@ public class PrivilegedPermissionTester extends SignaturePermissionTester {
                 continue;
             }
             if (mPermissionTasks.containsKey(permission)) {
-                testPassed = runPermissionTest(permission, mPermissionTasks.get(permission));
+                testPassed = runPermissionTest(permission, mPermissionTasks.get(permission), true);
             } else {
                 testPassed = getAndLogTestStatus(permission);
             }

--- a/niap-cc/Permissions/Tester/app/src/main/java/com/android/certifications/niap/permissions/activities/MainActivity.java
+++ b/niap-cc/Permissions/Tester/app/src/main/java/com/android/certifications/niap/permissions/activities/MainActivity.java
@@ -141,8 +141,8 @@ public class MainActivity extends AppCompatActivity {
             notificationManager.createNotificationChannel(channel);
 
             Intent notificationIntent = new Intent(mContext, MainActivity.class);
-            PendingIntent pendingIntent =
-                    PendingIntent.getActivity(mContext, 0, notificationIntent, 0);
+            PendingIntent pendingIntent = PendingIntent.getActivity(mContext, 0, notificationIntent,
+                    PendingIntent.FLAG_IMMUTABLE);
             Notification notification =
                     new Notification.Builder(mContext, TAG)
                             .setContentTitle(resources.getText(R.string.status_notification_title))

--- a/niap-cc/Permissions/Tester/app/src/main/java/com/android/certifications/niap/permissions/config/DebugConfiguration.java
+++ b/niap-cc/Permissions/Tester/app/src/main/java/com/android/certifications/niap/permissions/config/DebugConfiguration.java
@@ -16,8 +16,6 @@
 
 package com.android.certifications.niap.permissions.config;
 
-import static com.android.certifications.niap.permissions.utils.SignaturePermissions.permission;
-
 import android.app.Activity;
 
 import com.android.certifications.niap.permissions.BasePermissionTester;
@@ -25,7 +23,6 @@ import com.android.certifications.niap.permissions.R;
 import com.android.certifications.niap.permissions.SignaturePermissionTester;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -52,11 +49,31 @@ class DebugConfiguration implements TestConfiguration {
     }
 
     @Override
+    public Optional<List<String>> getInstallPermissions() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<List<String>> getRuntimePermissions() {
+        return Optional.empty();
+    }
+
+    @Override
     public Optional<List<String>> getSignaturePermissions() {
         // Returning a single signature permission will allow debug of the test for that one
         // permission; this is useful during development when creating tests for new permissions
         // declared in a release.
-        return Optional.of(Collections.singletonList(permission.BIND_QUICK_SETTINGS_TILE));
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<List<String>> getInternalPermissions() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<List<String>> getPermissions() {
+        return Optional.empty();
     }
 
     @Override

--- a/niap-cc/Permissions/Tester/app/src/main/java/com/android/certifications/niap/permissions/config/PlatformSignedDefaultConfiguration.java
+++ b/niap-cc/Permissions/Tester/app/src/main/java/com/android/certifications/niap/permissions/config/PlatformSignedDefaultConfiguration.java
@@ -18,6 +18,8 @@ package com.android.certifications.niap.permissions.config;
 
 import static com.android.certifications.niap.permissions.utils.SignaturePermissions.permission;
 
+import com.android.certifications.niap.permissions.utils.InternalPermissions;
+
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
@@ -25,11 +27,20 @@ import java.util.Set;
 /**
  * Configuration designed to perform permission tests with an app signed by the platform's signing
  * key. This configuration is intended to skip any tests that could cause the app to be
- * interrupted.
+ * interrupted, or that are expected to fail due to the permissions granted to the platform signed
+ * app.
  */
 class PlatformSignedDefaultConfiguration implements TestConfiguration {
     @Override
     public Optional<Set<String>> getSkippedSignaturePermissions() {
         return Optional.of(Collections.singleton(permission.MANAGE_BIOMETRIC_DIALOG));
+    }
+
+    @Override
+    public Optional<Set<String>> getSkippedInternalPermissions() {
+        // The DomainVerificationEnforcer will also check for the INTENT_FILTER_VERIFICATION_AGENT
+        // permission if this internal permission is not granted.
+        return Optional.of(
+                Collections.singleton(InternalPermissions.permission.DOMAIN_VERIFICATION_AGENT));
     }
 }

--- a/niap-cc/Permissions/Tester/app/src/main/java/com/android/certifications/niap/permissions/config/TestConfiguration.java
+++ b/niap-cc/Permissions/Tester/app/src/main/java/com/android/certifications/niap/permissions/config/TestConfiguration.java
@@ -21,6 +21,7 @@ import android.app.Activity;
 import com.android.certifications.niap.permissions.BasePermissionTester;
 import com.android.certifications.niap.permissions.Constants;
 import com.android.certifications.niap.permissions.InstallPermissionTester;
+import com.android.certifications.niap.permissions.InternalPermissionTester;
 import com.android.certifications.niap.permissions.PrivilegedPermissionTester;
 import com.android.certifications.niap.permissions.R;
 import com.android.certifications.niap.permissions.RuntimePermissionTester;
@@ -54,6 +55,7 @@ public interface TestConfiguration {
         if (Constants.USE_PRIVILEGED_PERMISSION_TESTER) {
             permissionTesters.add(new PrivilegedPermissionTester(this, activity));
         }
+        permissionTesters.add(new InternalPermissionTester(this, activity));
         permissionTesters.add(new InstallPermissionTester(this, activity));
         return permissionTesters;
     }
@@ -99,6 +101,14 @@ public interface TestConfiguration {
     }
 
     /**
+     * Returns an {@link Optional} containing a {@link List} of internal permissions to test, or
+     * {@link Optional#empty()}} if all internal permissions should be tested.
+     */
+    default Optional<List<String>> getInternalPermissions() {
+        return Optional.empty();
+    }
+
+    /**
      * Returns an {@link Optional} containing a {@link List} of permissions to test, or {@link
      * Optional#empty()} if all permissions should be tested.
      *
@@ -114,6 +124,14 @@ public interface TestConfiguration {
      * or {@link Optional#empty()} if no signature permissions should be skipped.
      */
     default Optional<Set<String>> getSkippedSignaturePermissions() {
+        return Optional.empty();
+    }
+
+    /**
+     * Returns an {@link Optional} containing a {@link Set} of internal permissions to be skipped,
+     * or {@link Optional#empty()} if no internal permissions should be skipped.
+     */
+    default Optional<Set<String>> getSkippedInternalPermissions() {
         return Optional.empty();
     }
 

--- a/niap-cc/Permissions/Tester/app/src/main/java/com/android/certifications/niap/permissions/services/TestService.java
+++ b/niap-cc/Permissions/Tester/app/src/main/java/com/android/certifications/niap/permissions/services/TestService.java
@@ -50,8 +50,8 @@ public class TestService extends Service {
             switch (permission) {
                 case Manifest.permission.FOREGROUND_SERVICE: {
                     Intent notificationIntent = new Intent(this, MainActivity.class);
-                    PendingIntent pendingIntent =
-                            PendingIntent.getActivity(this, 0, notificationIntent, 0);
+                    PendingIntent pendingIntent = PendingIntent.getActivity(this, 0,
+                            notificationIntent, PendingIntent.FLAG_IMMUTABLE);
 
                     // Create a NotificationChannel to be used to start the service in the
                     // foreground.

--- a/niap-cc/Permissions/Tester/app/src/main/java/com/android/certifications/niap/permissions/utils/InternalPermissions.java
+++ b/niap-cc/Permissions/Tester/app/src/main/java/com/android/certifications/niap/permissions/utils/InternalPermissions.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.certifications.niap.permissions.utils;
+
+/**
+ * Android 12 introduced a new protection level for permissions: permissions with the new internal
+ * protection level are no longer automatically granted to requesting apps that are signed with the
+ * platform's key, but instead are only granted when an app meets other requirements as declared
+ * by the permission's protection flags. Similar to signature permissions, the platform declared
+ * internal protection level permissions are hidden from apps. This class provides definitions for
+ * all of the platform internal permissions.
+ */
+public class InternalPermissions {
+    /**
+     * Definition of all of the internal protection level permissions declared by the platform.
+     */
+    public static class permission {
+        public static final String ACCESS_RCS_USER_CAPABILITY_EXCHANGE =
+                "android.permission.ACCESS_RCS_USER_CAPABILITY_EXCHANGE";
+        public static final String ASSOCIATE_COMPANION_DEVICES =
+                "android.permission.ASSOCIATE_COMPANION_DEVICES";
+        public static final String BACKGROUND_CAMERA = "android.permission.BACKGROUND_CAMERA";
+        public static final String BYPASS_ROLE_QUALIFICATION =
+                "android.permission.BYPASS_ROLE_QUALIFICATION";
+        public static final String DOMAIN_VERIFICATION_AGENT =
+                "android.permission.DOMAIN_VERIFICATION_AGENT";
+        public static final String MANAGE_HOTWORD_DETECTION =
+                "android.permission.MANAGE_HOTWORD_DETECTION";
+        public static final String OBSERVE_SENSOR_PRIVACY =
+                "android.permission.OBSERVE_SENSOR_PRIVACY";
+        public static final String PERFORM_IMS_SINGLE_REGISTRATION =
+                "android.permission.PERFORM_IMS_SINGLE_REGISTRATION";
+        public static final String RECORD_BACKGROUND_AUDIO =
+                "android.permission.RECORD_BACKGROUND_AUDIO";
+    }
+}

--- a/niap-cc/Permissions/Tester/app/src/main/java/com/android/certifications/niap/permissions/utils/SignaturePermissions.java
+++ b/niap-cc/Permissions/Tester/app/src/main/java/com/android/certifications/niap/permissions/utils/SignaturePermissions.java
@@ -830,6 +830,151 @@ public class SignaturePermissions {
         public static final String WHITELIST_AUTO_REVOKE_PERMISSIONS =
                 "android.permission.WHITELIST_AUTO_REVOKE_PERMISSIONS";
         public static final String USE_INSTALLER_V2 = "com.android.permission.USE_INSTALLER_V2";
+
+        // The following are the new signature permissions for Android 12.
+        public static final String ACCESS_BLOBS_ACROSS_USERS =
+                "android.permission.ACCESS_BLOBS_ACROSS_USERS";
+        public static final String ACCESS_TUNED_INFO = "android.permission.ACCESS_TUNED_INFO";
+        public static final String ASSOCIATE_INPUT_DEVICE_TO_DISPLAY =
+                "android.permission.ASSOCIATE_INPUT_DEVICE_TO_DISPLAY";
+        public static final String BATTERY_PREDICTION = "android.permission.BATTERY_PREDICTION";
+        public static final String BIND_CALL_DIAGNOSTIC_SERVICE =
+                "android.permission.BIND_CALL_DIAGNOSTIC_SERVICE";
+        public static final String BIND_COMPANION_DEVICE_SERVICE =
+                "android.permission.BIND_COMPANION_DEVICE_SERVICE";
+        public static final String BIND_DISPLAY_HASHING_SERVICE =
+                "android.permission.BIND_DISPLAY_HASHING_SERVICE";
+        public static final String BIND_DOMAIN_VERIFICATION_AGENT =
+                "android.permission.BIND_DOMAIN_VERIFICATION_AGENT";
+        public static final String BIND_GBA_SERVICE = "android.permission.BIND_GBA_SERVICE";
+        public static final String BIND_HOTWORD_DETECTION_SERVICE =
+                "android.permission.BIND_HOTWORD_DETECTION_SERVICE";
+        public static final String BIND_MUSIC_RECOGNITION_SERVICE =
+                "android.permission.BIND_MUSIC_RECOGNITION_SERVICE";
+        public static final String BIND_RESUME_ON_REBOOT_SERVICE =
+                "android.permission.BIND_RESUME_ON_REBOOT_SERVICE";
+        public static final String BIND_ROTATION_RESOLVER_SERVICE =
+                "android.permission.BIND_ROTATION_RESOLVER_SERVICE";
+        public static final String BIND_TIME_ZONE_PROVIDER_SERVICE =
+                "android.permission.BIND_TIME_ZONE_PROVIDER_SERVICE";
+        public static final String BIND_TRANSLATION_SERVICE =
+                "android.permission.BIND_TRANSLATION_SERVICE";
+        public static final String BROADCAST_CLOSE_SYSTEM_DIALOGS =
+                "android.permission.BROADCAST_CLOSE_SYSTEM_DIALOGS";
+        public static final String CAMERA_INJECT_EXTERNAL_CAMERA =
+                "android.permission.CAMERA_INJECT_EXTERNAL_CAMERA";
+        public static final String CAPTURE_BLACKOUT_CONTENT =
+                "android.permission.CAPTURE_BLACKOUT_CONTENT";
+        public static final String CAPTURE_TUNER_AUDIO_INPUT =
+                "android.permission.CAPTURE_TUNER_AUDIO_INPUT";
+        public static final String CLEAR_FREEZE_PERIOD = "android.permission.CLEAR_FREEZE_PERIOD";
+        public static final String CONTROL_DEVICE_STATE = "android.permission.CONTROL_DEVICE_STATE";
+        public static final String CONTROL_OEM_PAID_NETWORK_PREFERENCE =
+                "android.permission.CONTROL_OEM_PAID_NETWORK_PREFERENCE";
+        public static final String CONTROL_UI_TRACING = "android.permission.CONTROL_UI_TRACING";
+        public static final String DISABLE_SYSTEM_SOUND_EFFECTS =
+                "android.permission.DISABLE_SYSTEM_SOUND_EFFECTS";
+        public static final String FORCE_DEVICE_POLICY_MANAGER_LOGS =
+                "android.permission.FORCE_DEVICE_POLICY_MANAGER_LOGS";
+        public static final String GET_PEOPLE_TILE_PREVIEW =
+                "android.permission.GET_PEOPLE_TILE_PREVIEW";
+        public static final String GET_RUNTIME_PERMISSION_GROUP_MAPPING =
+                "android.permission.GET_RUNTIME_PERMISSION_GROUP_MAPPING";
+        public static final String INPUT_CONSUMER = "android.permission.INPUT_CONSUMER";
+        public static final String INSTALL_LOCATION_TIME_ZONE_PROVIDER_SERVICE =
+                "android.permission.INSTALL_LOCATION_TIME_ZONE_PROVIDER_SERVICE";
+        public static final String INSTALL_TEST_ONLY_PACKAGE =
+                "android.permission.INSTALL_TEST_ONLY_PACKAGE";
+        public static final String KEEP_UNINSTALLED_PACKAGES =
+                "android.permission.KEEP_UNINSTALLED_PACKAGES";
+        public static final String MANAGE_ACTIVITY_TASKS =
+                "android.permission.MANAGE_ACTIVITY_TASKS";
+        public static final String MANAGE_APP_HIBERNATION =
+                "android.permission.MANAGE_APP_HIBERNATION";
+        public static final String MANAGE_CREDENTIAL_MANAGEMENT_APP =
+                "android.permission.MANAGE_CREDENTIAL_MANAGEMENT_APP";
+        public static final String MANAGE_GAME_MODE = "android.permission.MANAGE_GAME_MODE";
+        public static final String MANAGE_MEDIA = "android.permission.MANAGE_MEDIA";
+        public static final String MANAGE_MUSIC_RECOGNITION =
+                "android.permission.MANAGE_MUSIC_RECOGNITION";
+        public static final String MANAGE_NOTIFICATION_LISTENERS =
+                "android.permission.MANAGE_NOTIFICATION_LISTENERS";
+        public static final String MANAGE_ONGOING_CALLS = "android.permission.MANAGE_ONGOING_CALLS";
+        public static final String MANAGE_ROTATION_RESOLVER =
+                "android.permission.MANAGE_ROTATION_RESOLVER";
+        public static final String MANAGE_SEARCH_UI = "android.permission.MANAGE_SEARCH_UI";
+        public static final String MANAGE_SMARTSPACE = "android.permission.MANAGE_SMARTSPACE";
+        public static final String MANAGE_SPEECH_RECOGNITION =
+                "android.permission.MANAGE_SPEECH_RECOGNITION";
+        public static final String MANAGE_TIME_AND_ZONE_DETECTION =
+                "android.permission.MANAGE_TIME_AND_ZONE_DETECTION";
+        public static final String MANAGE_TOAST_RATE_LIMITING =
+                "android.permission.MANAGE_TOAST_RATE_LIMITING";
+        public static final String MANAGE_UI_TRANSLATION =
+                "android.permission.MANAGE_UI_TRANSLATION";
+        public static final String MANAGE_WIFI_COUNTRY_CODE =
+                "android.permission.MANAGE_WIFI_COUNTRY_CODE";
+        public static final String MODIFY_REFRESH_RATE_SWITCHING_TYPE =
+                "android.permission.MODIFY_REFRESH_RATE_SWITCHING_TYPE";
+        public static final String NFC_SET_CONTROLLER_ALWAYS_ON =
+                "android.permission.NFC_SET_CONTROLLER_ALWAYS_ON";
+        public static final String OVERRIDE_COMPAT_CHANGE_CONFIG_ON_RELEASE_BUILD =
+                "android.permission.OVERRIDE_COMPAT_CHANGE_CONFIG_ON_RELEASE_BUILD";
+        public static final String OVERRIDE_DISPLAY_MODE_REQUESTS =
+                "android.permission.OVERRIDE_DISPLAY_MODE_REQUESTS";
+        public static final String QUERY_AUDIO_STATE = "android.permission.QUERY_AUDIO_STATE";
+        public static final String READ_DREAM_SUPPRESSION =
+                "android.permission.READ_DREAM_SUPPRESSION";
+        public static final String READ_NEARBY_STREAMING_POLICY =
+                "android.permission.READ_NEARBY_STREAMING_POLICY";
+        public static final String READ_PEOPLE_DATA = "android.permission.READ_PEOPLE_DATA";
+        public static final String READ_PROJECTION_STATE =
+                "android.permission.READ_PROJECTION_STATE";
+        public static final String REGISTER_MEDIA_RESOURCE_OBSERVER =
+                "android.permission.REGISTER_MEDIA_RESOURCE_OBSERVER";
+        public static final String RENOUNCE_PERMISSIONS = "android.permission.RENOUNCE_PERMISSIONS";
+        public static final String RESET_APP_ERRORS = "android.permission.RESET_APP_ERRORS";
+        public static final String RESTART_WIFI_SUBSYSTEM =
+                "android.permission.RESTART_WIFI_SUBSYSTEM";
+        public static final String ROTATE_SURFACE_FLINGER =
+                "android.permission.ROTATE_SURFACE_FLINGER";
+        public static final String SCHEDULE_PRIORITIZED_ALARM =
+                "android.permission.SCHEDULE_PRIORITIZED_ALARM";
+        public static final String SEND_CATEGORY_CAR_NOTIFICATIONS =
+                "android.permission.SEND_CATEGORY_CAR_NOTIFICATIONS";
+        public static final String SET_AND_VERIFY_LOCKSCREEN_CREDENTIALS =
+                "android.permission.SET_AND_VERIFY_LOCKSCREEN_CREDENTIALS";
+        public static final String SET_CLIP_SOURCE = "android.permission.SET_CLIP_SOURCE";
+        public static final String SIGNAL_REBOOT_READINESS =
+                "android.permission.SIGNAL_REBOOT_READINESS";
+        public static final String SOUNDTRIGGER_DELEGATE_IDENTITY =
+                "android.permission.SOUNDTRIGGER_DELEGATE_IDENTITY";
+        public static final String SOUND_TRIGGER_RUN_IN_BATTERY_SAVER =
+                "android.permission.SOUND_TRIGGER_RUN_IN_BATTERY_SAVER";
+        public static final String START_FOREGROUND_SERVICES_FROM_BACKGROUND =
+                "android.permission.START_FOREGROUND_SERVICES_FROM_BACKGROUND";
+        public static final String SUGGEST_EXTERNAL_TIME =
+                "android.permission.SUGGEST_EXTERNAL_TIME";
+        public static final String SYSTEM_APPLICATION_OVERLAY =
+                "android.permission.SYSTEM_APPLICATION_OVERLAY";
+        public static final String TEST_BIOMETRIC = "android.permission.TEST_BIOMETRIC";
+        public static final String TOGGLE_AUTOMOTIVE_PROJECTION =
+                "android.permission.TOGGLE_AUTOMOTIVE_PROJECTION";
+        public static final String UNLIMITED_TOASTS = "android.permission.UNLIMITED_TOASTS";
+        public static final String UPDATE_DOMAIN_VERIFICATION_USER_SELECTION =
+                "android.permission.UPDATE_DOMAIN_VERIFICATION_USER_SELECTION";
+        public static final String UPDATE_FONTS = "android.permission.UPDATE_FONTS";
+        public static final String USE_ICC_AUTH_WITH_DEVICE_IDENTIFIER =
+                "android.permission.USE_ICC_AUTH_WITH_DEVICE_IDENTIFIER";
+        public static final String UWB_PRIVILEGED = "android.permission.UWB_PRIVILEGED";
+        public static final String VIRTUAL_INPUT_DEVICE = "android.permission.VIRTUAL_INPUT_DEVICE";
+        public static final String WIFI_ACCESS_COEX_UNSAFE_CHANNELS =
+                "android.permission.WIFI_ACCESS_COEX_UNSAFE_CHANNELS";
+        public static final String WIFI_UPDATE_COEX_UNSAFE_CHANNELS =
+                "android.permission.WIFI_UPDATE_COEX_UNSAFE_CHANNELS";
+        public static final String USE_SYSTEM_DATA_LOADERS =
+                "com.android.permission.USE_SYSTEM_DATA_LOADERS";
+
     }
 
     /**

--- a/niap-cc/Permissions/Tester/app/src/main/res/values/strings.xml
+++ b/niap-cc/Permissions/Tester/app/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
   <string name="app_name">Permissions Tester</string>
   <string name="service_channel_name">Test Service Channel</string>
   <string name="tester_channel_name">Test Notification Channel</string>
+  <string name="test_notification_message">Test Notification</string>
   <string name="service_notification_title">PermissionsTester Service</string>
   <string name="service_notification_message">Notification to test FOREGROUND_SERVICE permission</string>
   <string name="status_notification_title">Permission Tester Status</string>
@@ -32,7 +33,6 @@
   <string name="run_non_platform_tests">Run Non-Platform Tests</string>
   <string name="run_access_media_location_test">Run ACCESS_MEDIA_LOCATION Test</string>
   <string name="run_permission_dependent_tests">Run Permission Dependent Tests</string>
-  <string name="run_radio_scan_without_location_test">Run RADIO_SCAN_WITHOUT_LOCATION Test</string>
   <string name="run_manage_biometric_dialog_test">Run MANAGE_BIOMETRIC_DIALOG Test</string>
   <string name="run_gms_tests">Run GMS Tests</string>
   <string name="run_debug_tests">Run Debug Tests</string>

--- a/niap-cc/Permissions/Tester/gradle.properties
+++ b/niap-cc/Permissions/Tester/gradle.properties
@@ -9,6 +9,7 @@
 android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
+android.injected.testOnly=false
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/niap-cc/Permissions/TransactIds/app/build.gradle
+++ b/niap-cc/Permissions/TransactIds/app/build.gradle
@@ -17,12 +17,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         applicationId "com.android.certifications.niap.permissions.transactids"
         minSdkVersion 28
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
 

--- a/niap-cc/Permissions/TransactIds/app/src/main/AndroidManifest.xml
+++ b/niap-cc/Permissions/TransactIds/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"
+            android:exported="true"
             android:label="@string/app_name"
             android:launchMode="singleTop">
             <intent-filter>

--- a/niap-cc/Permissions/TransactIds/app/src/main/java/com/android/certifications/niap/permissions/transactids/MainActivity.java
+++ b/niap-cc/Permissions/TransactIds/app/src/main/java/com/android/certifications/niap/permissions/transactids/MainActivity.java
@@ -117,6 +117,11 @@ public class MainActivity extends AppCompatActivity {
             transactIds.put(Transacts.bootFinished, "1");
             transactIds.put(Transacts.showCpu, "1000");
             descriptorTransacts.put(Transacts.SURFACE_FLINGER_DESCRIPTOR, transactIds);
+            // Special case: IResourceObserverService is a native service that cannot be queried
+            // directly through reflection, 2 is the transact ID for unregisterObserver.
+            transactIds = new HashMap<>();
+            transactIds.put(Transacts.unregisterObserver, "2");
+            descriptorTransacts.put(Transacts.RESOURCE_OBSERVER_DESCRIPTOR, transactIds);
 
             // This is the full list of direct binder transacts invoked by the Permission Test Tool
             // for all supported API levels. Any new transacts should be added to this list to
@@ -404,6 +409,131 @@ public class MainActivity extends AppCompatActivity {
                     descriptorTransacts);
             queryTransactId(Transacts.WINDOW_DESCRIPTOR, Transacts.thawRotation,
                     descriptorTransacts);
+
+            // The following are the transacts required for new permissions in Android 12.
+            queryTransactId(Transacts.CAMERA_DESCRIPTOR, Transacts.injectCamera,
+                    descriptorTransacts);
+            queryTransactId(Transacts.DEVICE_POLICY_DESCRIPTOR,
+                    Transacts.clearSystemUpdatePolicyFreezePeriodRecord, descriptorTransacts);
+            queryTransactId(Transacts.DEVICE_STATE_DESCRIPTOR, Transacts.cancelRequest,
+                    descriptorTransacts);
+            queryTransactId(Transacts.DEVICE_POLICY_DESCRIPTOR, Transacts.forceSecurityLogs,
+                    descriptorTransacts);
+            queryTransactId(Transacts.WINDOW_DESCRIPTOR, Transacts.createInputConsumer,
+                    descriptorTransacts);
+            queryTransactId(Transacts.PACKAGE_DESCRIPTOR, Transacts.setKeepUninstalledPackages,
+                    descriptorTransacts);
+            queryTransactId(Transacts.KEY_CHAIN_DESCRIPTOR, Transacts.removeCredentialManagementApp,
+                    descriptorTransacts);
+            queryTransactId(Transacts.GAME_DESCRIPTOR, Transacts.getAvailableGameModes,
+                    descriptorTransacts);
+            queryTransactId(Transacts.SMART_SPACE_DESCRIPTOR, Transacts.destroySmartspaceSession,
+                    descriptorTransacts);
+            queryTransactId(Transacts.SPEECH_RECOGNITION_DESCRIPTOR,
+                    Transacts.setTemporaryComponent, descriptorTransacts);
+            queryTransactId(Transacts.NOTIFICATION_DESCRIPTOR,
+                    Transacts.setToastRateLimitingEnabled, descriptorTransacts);
+            queryTransactId(Transacts.WIFI_DESCRIPTOR, Transacts.setOverrideCountryCode,
+                    descriptorTransacts);
+            queryTransactId(Transacts.DISPLAY_DESCRIPTOR, Transacts.setRefreshRateSwitchingType,
+                    descriptorTransacts);
+            queryTransactId(Transacts.DISPLAY_DESCRIPTOR,
+                    Transacts.shouldAlwaysRespectAppRequestedMode, descriptorTransacts);
+            queryTransactId(Transacts.AUDIO_DESCRIPTOR, Transacts.getDeviceVolumeBehavior,
+                    descriptorTransacts);
+            queryTransactId(Transacts.POWER_DESCRIPTOR,
+                    Transacts.isAmbientDisplaySuppressedForTokenByApp, descriptorTransacts);
+            queryTransactId(Transacts.UI_MODE_DESCRIPTOR, Transacts.getActiveProjectionTypes,
+                    descriptorTransacts);
+            queryTransactId(Transacts.ACTIVITY_DESCRIPTOR, Transacts.resetAppErrors,
+                    descriptorTransacts);
+            queryTransactId(Transacts.LOCK_SETTINGS_DESCRIPTOR, Transacts.verifyCredential,
+                    descriptorTransacts);
+            queryTransactId(Transacts.AUTH_DESCRIPTOR, Transacts.getUiPackage, descriptorTransacts);
+            queryTransactId(Transacts.DOMAIN_VERIFICATION_DESCRIPTOR,
+                    Transacts.setDomainVerificationLinkHandlingAllowed, descriptorTransacts);
+            queryTransactId(Transacts.NOTIFICATION_DESCRIPTOR,
+                    Transacts.getEnabledNotificationListeners, descriptorTransacts);
+            queryTransactId(Transacts.POWER_DESCRIPTOR, Transacts.setBatteryDischargePrediction,
+                    descriptorTransacts);
+            queryTransactId(Transacts.TIME_DETECTOR_DESCRIPTOR,
+                    Transacts.getCapabilitiesAndConfig, descriptorTransacts);
+            queryTransactId(Transacts.NFC_DESCRIPTOR, Transacts.isControllerAlwaysOnSupported,
+                    descriptorTransacts);
+            queryTransactId(Transacts.PLATFORM_COMPAT_DESCRIPTOR,
+                    Transacts.removeOverridesOnReleaseBuilds, descriptorTransacts);
+            queryTransactId(Transacts.DEVICE_POLICY_DESCRIPTOR,
+                    Transacts.getNearbyNotificationStreamingPolicy, descriptorTransacts);
+            queryTransactId(Transacts.PERMISSION_CHECKER_DESCRIPTOR, Transacts.checkPermission,
+                    descriptorTransacts);
+            queryTransactId(Transacts.WIFI_DESCRIPTOR, Transacts.restartWifiSubsystem,
+                    descriptorTransacts);
+            queryTransactId(Transacts.ALARM_DESCRIPTOR, Transacts.set, descriptorTransacts);
+            queryTransactId(Transacts.REBOOT_READINESS_DESCRIPTOR,
+                    Transacts.removeRequestRebootReadinessStatusListener, descriptorTransacts);
+            queryTransactId(Transacts.SOUND_TRIGGER_DESCRIPTOR, Transacts.attachAsMiddleman,
+                    descriptorTransacts);
+            queryTransactId(Transacts.TIME_DETECTOR_DESCRIPTOR, Transacts.suggestExternalTime,
+                    descriptorTransacts);
+            queryTransactId(Transacts.UI_MODE_DESCRIPTOR, Transacts.requestProjection,
+                    descriptorTransacts);
+            queryTransactId(Transacts.FONT_DESCRIPTOR, Transacts.getFontConfig,
+                    descriptorTransacts);
+            queryTransactId(Transacts.UWB_DESCRIPTOR, Transacts.getSpecificationInfo,
+                    descriptorTransacts);
+            queryTransactId(Transacts.MUSIC_RECOGNITION_DESCRIPTOR, Transacts.beginRecognition,
+                    descriptorTransacts);
+            queryTransactId(Transacts.TRANSLATION_DESCRIPTOR, Transacts.updateUiTranslationState,
+                    descriptorTransacts);
+            queryTransactId(Transacts.TV_INPUT_DESCRIPTOR, Transacts.getCurrentTunedInfos,
+                    descriptorTransacts);
+            queryTransactId(Transacts.ACTIVITY_TASK_DESCRIPTOR,
+                    Transacts.getWindowOrganizerController, descriptorTransacts);
+            queryTransactId(Transacts.CLIPBOARD_DESCRIPTOR, Transacts.getPrimaryClipSource,
+                    descriptorTransacts);
+            queryTransactId(Transacts.PEOPLE_DESCRIPTOR, Transacts.isConversation,
+                    descriptorTransacts);
+            queryTransactId(Transacts.WIFI_DESCRIPTOR, Transacts.unregisterCoexCallback,
+                    descriptorTransacts);
+            queryTransactId(Transacts.WIFI_DESCRIPTOR, Transacts.setCoexUnsafeChannels,
+                    descriptorTransacts);
+            queryTransactId(Transacts.VOICE_INTERACTION_DESCRIPTOR, Transacts.updateState,
+                    descriptorTransacts);
+            queryTransactId(Transacts.SENSOR_PRIVACY_DESCRIPTOR, Transacts.isSensorPrivacyEnabled,
+                    descriptorTransacts);
+            queryTransactId(Transacts.DOMAIN_VERIFICATION_DESCRIPTOR,
+                    Transacts.queryValidVerificationPackageNames, descriptorTransacts);
+            queryTransactId(Transacts.TELEPHONY_IMS_DESCRIPTOR, Transacts.requestAvailability,
+                    descriptorTransacts);
+            queryTransactId(Transacts.COMPANION_DEVICE_DESCRIPTOR, Transacts.createAssociation,
+                    descriptorTransacts);
+            queryTransactId(Transacts.ROLE_DESCRIPTOR, Transacts.setBypassingRoleQualification,
+                    descriptorTransacts);
+            queryTransactId(Transacts.TELEPHONY_IMS_DESCRIPTOR,
+                    Transacts.triggerNetworkRegistration, descriptorTransacts);
+            queryTransactId(Transacts.VPN_DESCRIPTOR, Transacts.getAlwaysOnVpnPackage,
+                    descriptorTransacts);
+            queryTransactId(Transacts.SOUND_TRIGGER_DESCRIPTOR, Transacts.attachAsOriginator,
+                    descriptorTransacts);
+            queryTransactId(Transacts.SOUND_TRIGGER_SESSION_DESCRIPTOR,
+                    Transacts.getModuleProperties, descriptorTransacts);
+            queryTransactId(Transacts.POWER_DESCRIPTOR, Transacts.setDynamicPowerSaveHint,
+                    descriptorTransacts);
+            queryTransactId(Transacts.FINGERPRINT_DESCRIPTOR, Transacts.resetLockout,
+                    descriptorTransacts);
+            queryTransactId(Transacts.PERMISSION_MANAGER_DESCRIPTOR, Transacts.isAutoRevokeExempted,
+                    descriptorTransacts);
+            queryTransactId(Transacts.NET_POLICY_DESCRIPTOR, Transacts.isUidNetworkingBlocked,
+                    descriptorTransacts);
+            queryTransactId(Transacts.VOICE_INTERACTION_DESCRIPTOR, Transacts.isSessionRunning,
+                    descriptorTransacts);
+            queryTransactId(Transacts.ACTIVITY_TASK_DESCRIPTOR,
+                    Transacts.getActivityClientController, descriptorTransacts);
+            queryTransactId(Transacts.ACTIVITY_CLIENT_DESCRIPTOR, Transacts.dismissKeyguard,
+                    descriptorTransacts);
+            queryTransactId(Transacts.CONNECTIVITY_DESCRIPTOR, Transacts.pendingRequestForNetwork,
+                    descriptorTransacts);
+            queryTransactId(Transacts.APP_OPS_DESCRIPTOR, Transacts.getUidOps, descriptorTransacts);
 
             return writeTransactsSourceFile(descriptorTransacts);
         }

--- a/niap-cc/Permissions/TransactIds/app/src/main/java/com/android/certifications/niap/permissions/transactids/Transacts.java
+++ b/niap-cc/Permissions/TransactIds/app/src/main/java/com/android/certifications/niap/permissions/transactids/Transacts.java
@@ -38,6 +38,8 @@ public class Transacts {
     public static final String ACCESSIBILITY_DESCRIPTOR =
             "android.view.accessibility.IAccessibilityManager";
 
+    public static final String ACTIVITY_CLIENT_DESCRIPTOR = "android.app.IActivityClientController";
+
     public static final String ACTIVITY_SERVICE = Context.ACTIVITY_SERVICE;
     public static final String ACTIVITY_DESCRIPTOR = "android.app.IActivityManager";
 
@@ -57,6 +59,9 @@ public class Transacts {
     public static final String AUDIO_SERVICE = Context.AUDIO_SERVICE;
     public static final String AUDIO_DESCRIPTOR = "android.media.IAudioService";
 
+    public static final String AUTH_SERVICE = "auth";
+    public static final String AUTH_DESCRIPTOR = "android.hardware.biometrics.IAuthService";
+
     public static final String BACKUP_SERVICE = "backup";
     public static final String BACKUP_DESCRIPTOR = "android.app.backup.IBackupManager";
 
@@ -70,6 +75,13 @@ public class Transacts {
     public static final String CAMERA_SERVICE = "media.camera";
     public static final String CAMERA_DESCRIPTOR = "android.hardware.ICameraService";
 
+    public static final String CLIPBOARD_SERVICE = Context.CLIPBOARD_SERVICE;
+    public static final String CLIPBOARD_DESCRIPTOR = "android.content.IClipboard";
+
+    public static final String COMPANION_DEVICE_SERVICE = Context.COMPANION_DEVICE_SERVICE;
+    public static final String COMPANION_DEVICE_DESCRIPTOR =
+            "android.companion.ICompanionDeviceManager";
+
     public static final String CONNECTIVITY_SERVICE = Context.CONNECTIVITY_SERVICE;
     public static final String CONNECTIVITY_DESCRIPTOR = "android.net.IConnectivityManager";
 
@@ -80,8 +92,15 @@ public class Transacts {
     public static final String DEVICE_POLICY_SERVICE = Context.DEVICE_POLICY_SERVICE;
     public static final String DEVICE_POLICY_DESCRIPTOR = "android.app.admin.IDevicePolicyManager";
 
+    public static final String DEVICE_STATE_SERVICE = "device_state";
+    public static final String DEVICE_STATE_DESCRIPTOR = "android.hardware.devicestate.IDeviceStateManager";
+
     public static final String DISPLAY_SERVICE = Context.DISPLAY_SERVICE;
     public static final String DISPLAY_DESCRIPTOR = "android.hardware.display.IDisplayManager";
+
+    public static final String DOMAIN_VERIFICATION_SERVICE = Context.DOMAIN_VERIFICATION_SERVICE;
+    public static final String DOMAIN_VERIFICATION_DESCRIPTOR =
+            "android.content.pm.verify.domain.IDomainVerificationManager";
 
     public static final String DREAMS_SERVICE = "dreams";
     public static final String DREAMS_DESCRIPTOR = "android.service.dreams.IDreamManager";
@@ -101,11 +120,23 @@ public class Transacts {
     public static final String FINGERPRINT_DESCRIPTOR =
             "android.hardware.fingerprint.IFingerprintService";
 
+    public static final String FONT_SERVICE = "font";
+    public static final String FONT_DESCRIPTOR = "com.android.internal.graphics.fonts.IFontManager";
+
+    public static final String GAME_SERVICE = Context.GAME_SERVICE;
+    public static final String GAME_DESCRIPTOR = "android.app.IGameManagerService";
+
     public static final String INPUT_SERVICE = Context.INPUT_SERVICE;
     public static final String INPUT_DESCRIPTOR = "android.hardware.input.IInputManager";
 
     public static final String ISUB_SERVICE = "isub";
     public static final String ISUB_DESCRIPTOR = "com.android.internal.telephony.ISub";
+
+    public static final String KEY_CHAIN_DESCRIPTOR = "android.security.IKeyChainService";
+
+    public static final String LOCK_SETTINGS_SERVICE = "lock_settings";
+    public static final String LOCK_SETTINGS_DESCRIPTOR =
+            "com.android.internal.widget.ILockSettings";
 
     public static final String MEDIA_PROJECTION_SERVICE = Context.MEDIA_PROJECTION_SERVICE;
     public static final String MEDIA_PROJECTION_DESCRIPTOR =
@@ -117,6 +148,10 @@ public class Transacts {
     public static final String MOUNT_SERVICE = "mount";
     public static final String MOUNT_DESCRIPTOR = "android.os.storage.IStorageManager";
 
+    public static final String MUSIC_RECOGNITION_SERVICE = "music_recognition";
+    public static final String MUSIC_RECOGNITION_DESCRIPTOR =
+            "android.media.musicrecognition.IMusicRecognitionManager";
+
     public static final String NET_POLICY_SERVICE = "netpolicy";
     public static final String NET_POLICY_DESCRIPTOR = "android.net.INetworkPolicyManager";
 
@@ -127,11 +162,21 @@ public class Transacts {
     public static final String NETWORK_STATS_SERVICE = Context.NETWORK_STATS_SERVICE;
     public static final String NETWORK_STATS_DESCRIPTOR = "android.net.INetworkStatsService";
 
+    public static final String NFC_SERVICE = Context.NFC_SERVICE;
+    public static final String NFC_DESCRIPTOR = "android.nfc.INfcAdapter";
+
     public static final String NOTIFICATION_SERVICE = Context.NOTIFICATION_SERVICE;
     public static final String NOTIFICATION_DESCRIPTOR = "android.app.INotificationManager";
 
     public static final String PACKAGE_SERVICE = "package";
     public static final String PACKAGE_DESCRIPTOR = "android.content.pm.IPackageManager";
+
+    public static final String PEOPLE_SERVICE = Context.PEOPLE_SERVICE;
+    public static final String PEOPLE_DESCRIPTOR = "android.app.people.IPeopleManager";
+
+    public static final String PERMISSION_CHECKER_SERVICE = "permission_checker";
+    public static final String PERMISSION_CHECKER_DESCRIPTOR =
+            "android.permission.IPermissionChecker";
 
     public static final String PERMISSION_MANAGER_SERVICE = "permissionmgr";
     public static final String PERMISSION_MANAGER_DESCRIPTOR =
@@ -144,9 +189,17 @@ public class Transacts {
     public static final String POWER_SERVICE = Context.POWER_SERVICE;
     public static final String POWER_DESCRIPTOR = "android.os.IPowerManager";
 
+    public static final String REBOOT_READINESS_SERVICE = "reboot_readiness";
+    public static final String REBOOT_READINESS_DESCRIPTOR =
+            "android.scheduling.IRebootReadinessManager";
+
     public static final String RESOURCE_MANAGER_SERVICE = "media.resource_manager";
     public static final String RESOURCE_MANAGER_DESCRIPTOR =
             "android.media.IResourceManagerService";
+
+    public static final String RESOURCE_OBSERVER_SERVICE = "media.resource_observer";
+    public static final String RESOURCE_OBSERVER_DESCRIPTOR =
+            "android.media.IResourceObserverService";
 
     public static final String ROLE_SERVICE = Context.ROLE_SERVICE;
     public static final String ROLE_DESCRIPTOR = "android.app.role.IRoleManager";
@@ -163,9 +216,19 @@ public class Transacts {
     public static final String SLICE_SERVICE = "slice";
     public static final String SLICE_DESCRIPTOR = "android.app.slice.ISliceManager";
 
+    public static final String SMART_SPACE_SERVICE = "smartspace";
+    public static final String SMART_SPACE_DESCRIPTOR = "android.app.smartspace.ISmartspaceManager";
+
     public static final String SOUND_TRIGGER_SERVICE = "soundtrigger";
     public static final String SOUND_TRIGGER_DESCRIPTOR =
             "com.android.internal.app.ISoundTriggerService";
+
+    public static final String SOUND_TRIGGER_SESSION_DESCRIPTOR =
+            "com.android.internal.app.ISoundTriggerSession";
+
+    public static final String SPEECH_RECOGNITION_SERVICE = "speech_recognition";
+    public static final String SPEECH_RECOGNITION_DESCRIPTOR =
+            "android.speech.IRecognitionServiceManager";
 
     public static final String STATUS_BAR_SERVICE = "statusbar";
     public static final String STATUS_BAR_DESCRIPTOR =
@@ -174,17 +237,38 @@ public class Transacts {
     public static final String SURFACE_FLINGER_SERVICE = "SurfaceFlinger";
     public static final String SURFACE_FLINGER_DESCRIPTOR = "android.ui.ISurfaceComposer";
 
+    public static final String TELEPHONY_IMS_SERVICE = "telephony_ims";
+    public static final String TELEPHONY_IMS_DESCRIPTOR =
+            "android.telephony.ims.aidl.IImsRcsController";
+
     public static final String TELEPHONY_SERVICE = Context.TELEPHONY_SERVICE;
     public static final String TELEPHONY_DESCRIPTOR = "com.android.internal.telephony.ITelephony";
 
+    public static final String TIME_DETECTOR_SERVICE = "time_detector";
+    public static final String TIME_DETECTOR_DESCRIPTOR =
+            "android.app.timedetector.ITimeDetectorService";
+
+    public static final String TRANSLATION_SERVICE = "translation";
+    public static final String TRANSLATION_DESCRIPTOR =
+            "android.view.translation.ITranslationManager";
+
     public static final String TRUST_SERVICE = "trust";
     public static final String TRUST_DESCRIPTOR = "android.app.trust.ITrustManager";
+
+    public static final String TV_INPUT_SERVICE = "tv_input";
+    public static final String TV_INPUT_DESCRIPTOR = "android.media.tv.ITvInputManager";
+
+    public static final String UI_MODE_SERVICE = Context.UI_MODE_SERVICE;
+    public static final String UI_MODE_DESCRIPTOR = "android.app.IUiModeManager";
 
     public static final String URI_GRANTS_SERVICE = "uri_grants";
     public static final String URI_GRANTS_DESCRIPTOR = "android.app.IUriGrantsManager";
 
     public static final String USB_SERVICE = Context.USB_SERVICE;
     public static final String USB_DESCRIPTOR = "android.hardware.usb.IUsbManager";
+
+    public static final String UWB_SERVICE = "uwb";
+    public static final String UWB_DESCRIPTOR = "android.uwb.IUwbAdapter";
 
     public static final String VIBRATOR_SERVICE = Context.VIBRATOR_SERVICE;
     public static final String VIBRATOR_DESCRIPTOR = "android.os.IVibratorService";
@@ -193,11 +277,15 @@ public class Transacts {
     public static final String VOICE_INTERACTION_DESCRIPTOR =
             "com.android.internal.app.IVoiceInteractionManagerService";
 
+    public static final String VPN_SERVICE = Context.VPN_MANAGEMENT_SERVICE;
+    public static final String VPN_DESCRIPTOR = "android.net.IVpnManager";
+
     public static final String VR_SERVICE = "vrmanager";
     public static final String VR_DESCRIPTOR = "android.service.vr.IVrManager";
 
     public static final String WALLPAPER_SERVICE = Context.WALLPAPER_SERVICE;
     public static final String WALLPAPER_DESCRIPTOR = "android.app.IWallpaperManager";
+
     public static final String WIFI_SERVICE = Context.WIFI_SERVICE;
     public static final String WIFI_DESCRIPTOR = "android.net.wifi.IWifiManager";
 
@@ -372,6 +460,77 @@ public class Transacts {
             "addOnRoleHoldersChangedListenerAsUser";
     public static final String forceUpdate = "forceUpdate";
     public static final String showCpu = "showCpu";
+    public static final String isControllerAlwaysOnSupported = "isControllerAlwaysOnSupported";
+    public static final String removeOverridesOnReleaseBuilds = "removeOverridesOnReleaseBuilds";
+    public static final String getNearbyNotificationStreamingPolicy =
+            "getNearbyNotificationStreamingPolicy";
+    public static final String restartWifiSubsystem = "restartWifiSubsystem";
+    public static final String set = "set";
+    public static final String removeRequestRebootReadinessStatusListener =
+            "removeRequestRebootReadinessStatusListener";
+    public static final String attachAsMiddleman = "attachAsMiddleman";
+    public static final String suggestExternalTime = "suggestExternalTime";
+
+    // The following are the transacts required for new permissions in Android 12.
+    public static final String injectCamera = "injectCamera";
+    public static final String clearSystemUpdatePolicyFreezePeriodRecord =
+            "clearSystemUpdatePolicyFreezePeriodRecord";
+    public static final String cancelRequest = "cancelRequest";
+    public static final String forceSecurityLogs = "forceSecurityLogs";
+    public static final String createInputConsumer = "createInputConsumer";
+    public static final String setKeepUninstalledPackages = "setKeepUninstalledPackages";
+    public static final String removeCredentialManagementApp = "removeCredentialManagementApp";
+    public static final String getAvailableGameModes = "getAvailableGameModes";
+    public static final String destroySmartspaceSession = "destroySmartspaceSession";
+    public static final String setTemporaryComponent = "setTemporaryComponent";
+    public static final String setToastRateLimitingEnabled = "setToastRateLimitingEnabled";
+    public static final String setOverrideCountryCode = "setOverrideCountryCode";
+    public static final String setRefreshRateSwitchingType = "setRefreshRateSwitchingType";
+    public static final String shouldAlwaysRespectAppRequestedMode =
+            "shouldAlwaysRespectAppRequestedMode";
+    public static final String getDeviceVolumeBehavior = "getDeviceVolumeBehavior";
+    public static final String isAmbientDisplaySuppressedForTokenByApp =
+            "isAmbientDisplaySuppressedForTokenByApp";
+    public static final String getActiveProjectionTypes = "getActiveProjectionTypes";
+    public static final String resetAppErrors = "resetAppErrors";
+    public static final String verifyCredential = "verifyCredential";
+    public static final String getUiPackage = "getUiPackage";
+    public static final String setDomainVerificationLinkHandlingAllowed =
+            "setDomainVerificationLinkHandlingAllowed";
+    public static final String getEnabledNotificationListeners = "getEnabledNotificationListeners";
+    public static final String setBatteryDischargePrediction = "setBatteryDischargePrediction";
+    public static final String getCapabilitiesAndConfig = "getCapabilitiesAndConfig";
+    public static final String unregisterObserver = "unregisterObserver";
+    public static final String checkPermission = "checkPermission";
+    public static final String requestProjection = "requestProjection";
+    public static final String getFontConfig = "getFontConfig";
+    public static final String getSpecificationInfo = "getSpecificationInfo";
+    public static final String beginRecognition = "beginRecognition";
+    public static final String updateUiTranslationState = "updateUiTranslationState";
+    public static final String getCurrentTunedInfos = "getCurrentTunedInfos";
+    public static final String getWindowOrganizerController = "getWindowOrganizerController";
+    public static final String getPrimaryClipSource = "getPrimaryClipSource";
+    public static final String isConversation = "isConversation";
+    public static final String unregisterCoexCallback = "unregisterCoexCallback";
+    public static final String setCoexUnsafeChannels = "setCoexUnsafeChannels";
+    public static final String updateState = "updateState";
+    public static final String isSensorPrivacyEnabled = "isSensorPrivacyEnabled";
+    public static final String queryValidVerificationPackageNames =
+            "queryValidVerificationPackageNames";
+    public static final String requestAvailability = "requestAvailability";
+    public static final String createAssociation = "createAssociation";
+    public static final String setBypassingRoleQualification = "setBypassingRoleQualification";
+    public static final String destroySipDelegate = "destroySipDelegate";
+    public static final String attachAsOriginator = "attachAsOriginator";
+    public static final String setDynamicPowerSaveHint = "setDynamicPowerSaveHint";
+    public static final String resetLockout = "resetLockout";
+    public static final String isAutoRevokeExempted = "isAutoRevokeExempted";
+    public static final String isUidNetworkingBlocked = "isUidNetworkingBlocked";
+    public static final String isSessionRunning = "isSessionRunning";
+    public static final String getActivityClientController = "getActivityClientController";
+    public static final String getModuleProperties = "getModuleProperties";
+    public static final String triggerNetworkRegistration = "triggerNetworkRegistration";
+    public static final String getUidOps = "getUidOps";
 
     /**
      * Mapping from the descriptor class to the constant variable name for use when writing an


### PR DESCRIPTION
This commit updates the Permission Tester and related apps
with support for Android 12 (API level 31); the BasePermissionTester
extensions have been updated to include tests for the new permissions
introduced in Android 12. This Android release also included support
for a new internal permission protection level; permissions declared
with this protection level are no longer granted to apps signed with
the platform's signing key, but instead a requesting app must satisfy
one of the other permission protection flags. This commit includes a
new instrumentation test that adopts the shell identity to test the
new internal protection permissions.