### PR TITLE
uranibog/Hubble: Upgrade gradle again.

### DIFF
--- a/uraniborg/AndroidStudioProject/Hubble/build.gradle
+++ b/uraniborg/AndroidStudioProject/Hubble/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
+        classpath 'com.android.tools.build:gradle:7.2.2'
         
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/uraniborg/AndroidStudioProject/Hubble/gradle/wrapper/gradle-wrapper.properties
+++ b/uraniborg/AndroidStudioProject/Hubble/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip


### PR DESCRIPTION
Upgrades gradle from 7.1.3 to 7.2.2.

Upgrades Android Gradle Plugin (AGP) from 7.2 to 7.3.3.

Test: Hubble still builds successfully.