### PR TITLE
uraniborg/Hubble: Upgrade Hubble to v.1.2.0.

### DIFF
--- a/uraniborg/AndroidStudioProject/Hubble/app/build.gradle
+++ b/uraniborg/AndroidStudioProject/Hubble/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 33
     defaultConfig {
         applicationId "com.uraniborg.hubble"
         minSdkVersion 23
-        targetSdkVersion 29
-        versionCode 2
-        versionName "1.1.0"
+        targetSdkVersion 33
+        versionCode 4
+        versionName "1.2.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/uraniborg/AndroidStudioProject/Hubble/app/src/main/AndroidManifest.xml
+++ b/uraniborg/AndroidStudioProject/Hubble/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:roundIcon="@mipmap/ic_launcher_text_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -18,5 +18,6 @@
             </intent-filter>
         </activity>
     </application>
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
 
 </manifest>

--- a/uraniborg/AndroidStudioProject/Hubble/app/src/main/java/com/uraniborg/hubble/MainActivity.java
+++ b/uraniborg/AndroidStudioProject/Hubble/app/src/main/java/com/uraniborg/hubble/MainActivity.java
@@ -44,7 +44,7 @@ import java.util.Locale;
 
 public class MainActivity extends AppCompatActivity {
   final String TAG = "HUBBLE";
-  private final String VERSION = "1.1.0";   // NOTE: to be updated for every Hubble release
+  private final String VERSION = "1.2.0";   // NOTE: to be updated for every Hubble release
 
   private HashMap<String, PackageMetadata> mAllPackages;
   private HashMap<String, byte[]> mAllCertificates;


### PR DESCRIPTION
Minor updates and changes to get Hubble to target API/SDK level 33.
Officially, this updates the versionName to "1.2.0" and versionCode to 4.

AndroidManifest.xml:
MainActivity has to be explicitly exported due to change in Android 12.
The necessary permission for Hubble to successfully probe packages is
also added, i.e. QUERY_ALL_PACKAGES.

MainActivity.java:
Version const is updated to reflect the updated versionName.