### PR TITLE
Niap secsampleapp update sdk33

### DIFF
--- a/niap-cc/NIAPSecExample/app/build.gradle
+++ b/niap-cc/NIAPSecExample/app/build.gradle
@@ -18,13 +18,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "30.0.0-rc4"
+    compileSdkVersion 33
+    buildToolsVersion "30.0.3"
 
     defaultConfig {
         applicationId "com.android.certifications.niap.sdp"
         minSdkVersion 28
-        targetSdkVersion 29
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
 
@@ -39,13 +39,14 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = '1.8'
-        targetCompatibility = '1.8'
+        sourceCompatibility = "1.8"
+        targetCompatibility = "1.8"
     }
 }
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
+
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'com.google.android.material:material:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
@@ -58,5 +59,8 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-
+    implementation('androidx.work:work-runtime:2.7.0') {
+        because 'previous versions have a bug impacting this application'
+    }
+    implementation 'info.guardianproject.netcipher:netcipher:2.2.0-alpha'
 }

--- a/niap-cc/NIAPSecExample/app/build.gradle
+++ b/niap-cc/NIAPSecExample/app/build.gradle
@@ -62,5 +62,4 @@ dependencies {
     implementation('androidx.work:work-runtime:2.7.0') {
         because 'previous versions have a bug impacting this application'
     }
-    implementation 'info.guardianproject.netcipher:netcipher:2.2.0-alpha'
 }

--- a/niap-cc/NIAPSecExample/app/src/main/AndroidManifest.xml
+++ b/niap-cc/NIAPSecExample/app/src/main/AndroidManifest.xml
@@ -11,12 +11,14 @@
      limitations under the License.
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.android.certifications.niap.niapsecexample">
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"
+        tools:ignore="CoarseFineLocation" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
@@ -34,6 +36,7 @@
         <activity
             android:name="com.android.certifications.niap.MainActivity"
             android:label="@string/app_name"
+            android:exported="true"
             android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/niap-cc/NIAPSecExample/app/src/main/java/com/android/certifications/niap/EncryptedDataService.java
+++ b/niap-cc/NIAPSecExample/app/src/main/java/com/android/certifications/niap/EncryptedDataService.java
@@ -26,6 +26,7 @@ import android.content.Intent;
 import android.os.Build;
 import android.util.Log;
 
+import com.android.certifications.niap.niapsec.SecureConfig;
 import com.android.certifications.niap.niapsec.biometric.BiometricSupport;
 import com.android.certifications.niap.niapsec.biometric.BiometricSupportImpl;
 import com.android.certifications.niap.niapsec.crypto.SecureCipher;
@@ -73,7 +74,7 @@ public class EncryptedDataService extends IntentService {
         super.onCreate();
         this.viewModel = MainActivity.viewModel;
         biometricSupport = new BiometricSupportImpl(MainActivity.thisActivity,
-                getApplicationContext()) {
+                getApplicationContext(),true) {
             @Override
             public void onAuthenticationSucceeded() {
                 showMessage(BIOMETRIC_AUTH + " Succeeded!");
@@ -84,10 +85,11 @@ public class EncryptedDataService extends IntentService {
                 onMessage(BIOMETRIC_AUTH + " Failed");
             }
 
+            /*
             @Override
             public void onAuthenticationCancelled() {
                 showMessage(BIOMETRIC_AUTH + " Cancelled!");
-            }
+            }*/
 
             @Override
             public void onMessage(String message) {
@@ -147,7 +149,7 @@ public class EncryptedDataService extends IntentService {
                 asymmetricKeyPairAlias,
                 testDataString.getBytes(),
                 (byte[] encryptedData) -> {
-            SecureCipher secureCipher = SecureCipher.getDefault(biometricSupport);
+            SecureCipher secureCipher = SecureCipher.getDefault((SecureConfig) biometricSupport);
             secureCipher.decryptEncodedData(encryptedData, (byte[] decryptedData) -> {
                 Log.i(TAG, "Decrypted... " + new String(decryptedData));
                 boolean encrypted = encryptData(fileName, (byte[] cipherText) -> {
@@ -197,7 +199,7 @@ public class EncryptedDataService extends IntentService {
 
         Intent notificationIntent = new Intent(this, EncryptedDataService.class);
         PendingIntent pendingIntent =
-                PendingIntent.getActivity(this, 0, notificationIntent, 0);
+                PendingIntent.getActivity(this, 0, notificationIntent, PendingIntent.FLAG_IMMUTABLE);
 
         Notification.Builder notificationBuilder = new Notification.Builder(
                 this,

--- a/niap-cc/NIAPSecExample/app/src/main/java/com/android/certifications/niap/EncryptedDataService.java
+++ b/niap-cc/NIAPSecExample/app/src/main/java/com/android/certifications/niap/EncryptedDataService.java
@@ -85,12 +85,6 @@ public class EncryptedDataService extends IntentService {
                 onMessage(BIOMETRIC_AUTH + " Failed");
             }
 
-            /*
-            @Override
-            public void onAuthenticationCancelled() {
-                showMessage(BIOMETRIC_AUTH + " Cancelled!");
-            }*/
-
             @Override
             public void onMessage(String message) {
                 showMessage(message);

--- a/niap-cc/NIAPSecExample/app/src/main/java/com/android/certifications/niap/EncryptionManager.java
+++ b/niap-cc/NIAPSecExample/app/src/main/java/com/android/certifications/niap/EncryptionManager.java
@@ -22,6 +22,7 @@ import android.util.Base64;
 import android.util.Log;
 import android.util.Pair;
 
+import com.android.certifications.niap.niapsec.SecureConfig;
 import com.android.certifications.niap.niapsec.biometric.BiometricSupport;
 import com.android.certifications.niap.niapsec.context.SecureContextCompat;
 import com.android.certifications.niap.niapsec.crypto.EphemeralSecretKey;
@@ -51,9 +52,9 @@ public class EncryptionManager {
 
     public void createSensitiveDataSymmetricKey(final String keyAlias) {
         Log.i(TAG, "Generating Key...");
-        SecureKeyGenerator keyGenerator = SecureKeyGenerator.getDefault();
+        SecureKeyGenerator keyGenerator = SecureKeyGenerator.getInstance(SecureConfig.getDefault());
         boolean created = keyGenerator.generateKey(keyAlias);
-        SecureKeyStore secureKeyStore = SecureKeyStore.getDefault();
+        SecureKeyStore secureKeyStore = SecureKeyStore.getDefault(SecureConfig.getDefault());
         final boolean keyInHardware = secureKeyStore.checkKeyInsideSecureHardware(keyAlias);
         if (UpdateViewModel.updateStatus != null) {
             UpdateViewModel.updateStatus.postValue("Generated Key Stored in Hardware: " +
@@ -63,10 +64,10 @@ public class EncryptionManager {
 
     public void createSensitiveDataAsymmetricKeyPair(final String keyPairAlias) {
         Log.i(TAG, "Generating KeyPair (RSA)...");
-        SecureKeyGenerator keyGenerator = SecureKeyGenerator.getDefault();
+        SecureKeyGenerator keyGenerator = SecureKeyGenerator.getInstance(SecureConfig.getDefault());
         boolean createdAsym = keyGenerator.generateAsymmetricKeyPair(keyPairAlias);
         Log.i(TAG, "KeyPair Generated: " + createdAsym);
-        SecureKeyStore secureKeyStore = SecureKeyStore.getDefault();
+        SecureKeyStore secureKeyStore = SecureKeyStore.getDefault(SecureConfig.getDefault());
         final boolean keyInHardwareAsym =
                 secureKeyStore.checkKeyInsideSecureHardwareAsymmetric(keyPairAlias);
         if (UpdateViewModel.updateStatus != null) {
@@ -76,7 +77,7 @@ public class EncryptionManager {
     }
 
     public EphemeralSecretKey createEphemeralKey() {
-        SecureKeyGenerator secureKeyGenerator = SecureKeyGenerator.getDefault();
+        SecureKeyGenerator secureKeyGenerator = SecureKeyGenerator.getInstance(SecureConfig.getDefault());
         EphemeralSecretKey secretKey = secureKeyGenerator.generateEphemeralDataKey();
         Log.i("SDPTestWorker", "Ephemeral AES Key Base64:\n" +
                 Base64.encodeToString(secretKey.getEncoded(), Base64.DEFAULT));
@@ -87,7 +88,7 @@ public class EncryptionManager {
             EphemeralSecretKey secretKey,
             String keyPairAlias,
             SecureCipher.SecureAsymmetricEncryptionCallback callback) {
-        SecureCipher secureCipher = SecureCipher.getDefault(biometricSupport);
+        SecureCipher secureCipher = SecureCipher.getDefault(SecureConfig.getDefault(biometricSupport));
         secureCipher.encryptSensitiveDataAsymmetric(keyPairAlias, secretKey.getEncoded(), callback);
     }
 
@@ -117,8 +118,8 @@ public class EncryptionManager {
             // Asymmetric Sensitive Data Protection
             Log.i(TAG, "Device Locked: Encrypted Data using Asymmetric Key");
             EphemeralSecretKey secretKey = createEphemeralKey();
-            SecureCipher secureCipher = SecureCipher.getDefault(biometricSupport);
-            Pair<byte[], byte[]> encryptedData = secureCipher.encryptEphemeralData(secretKey, data);
+            SecureCipher secureCipher = SecureCipher.getDefault(SecureConfig.getDefault(biometricSupport));
+            Pair<byte[], byte[]> encryptedData = secureCipher.encryptEphemeralData(secretKey, data,"default_encryption_key");
             encryptEphemeralKeyAsymmetric(secretKey, asymKeyPairAlias,
                     (byte[] encryptedEphemeralKey) -> {
                 byte[] encodedData = secureCipher.encodeEphemeralData(
@@ -130,7 +131,7 @@ public class EncryptionManager {
                 asymmetricEncryptionCallback.encryptionComplete(encodedData);
             });
         } else {
-            SecureCipher secureCipher = SecureCipher.getDefault(biometricSupport);
+            SecureCipher secureCipher = SecureCipher.getDefault(SecureConfig.getDefault(biometricSupport));
             secureCipher.encryptSensitiveData(
                     symKeyAlias,
                     data,
@@ -152,12 +153,12 @@ public class EncryptionManager {
         final AtomicBoolean saved = new AtomicBoolean(false);
         encryptData(symKeyAlias, asymKeyPairAlias, data, (byte[] encryptedData) -> {
             try {
-                SecureContextCompat secureContext = new SecureContextCompat(context);
+                SecureContextCompat secureContext = new SecureContextCompat(context,SecureConfig.getDefault());
                 Log.i(TAG, "Keyname " + fileName.substring(0, fileName.indexOf(".")));
                 FileOutputStream outputStream = secureContext.openEncryptedFileOutput(
                         fileName,
                         Context.MODE_PRIVATE,
-                        fileName.substring(0, fileName.indexOf(".")));
+                        fileName.substring(0, fileName.indexOf(".")),true);
                 outputStream.write(encryptedData);
                 UpdateViewModel.updateStatus.postValue(
                         "Saving " + encryptedData.length + " bytes to file " + fileName);
@@ -177,7 +178,7 @@ public class EncryptionManager {
             byte[] encodedCipherText,
             SecureCipher.SecureAsymmetricEncryptionCallback callback) {
         if (!deviceLocked()) {
-            SecureCipher secureCipher = SecureCipher.getDefault(biometricSupport);
+            SecureCipher secureCipher = SecureCipher.getDefault(SecureConfig.getDefault(biometricSupport));
             secureCipher.decryptEncodedData(
                     encodedCipherText,
                     (byte[] decryptedData) -> {
@@ -198,11 +199,12 @@ public class EncryptionManager {
     public boolean convertEphemeralEncodedData(String fileName, String keyPairAlias) {
         AtomicBoolean converted = new AtomicBoolean(false);
         try {
-            SecureContextCompat secureContext = new SecureContextCompat(context);
+            SecureContextCompat secureContext = new SecureContextCompat(context,SecureConfig.getDefault());
             secureContext.openEncryptedFileInput(
                     fileName,
                     Executors.newSingleThreadExecutor(),
-                    inputStream -> {
+                    true,
+                    inputStream-> {
                 try {
                     byte[] fileData = new byte[inputStream.available()];
                     inputStream.read(fileData);
@@ -216,7 +218,7 @@ public class EncryptionManager {
                                         .openEncryptedFileOutput(
                                                 fileName,
                                                 Context.MODE_PRIVATE,
-                                                fileName.substring(0, fileName.indexOf(".")));
+                                                fileName.substring(0, fileName.indexOf(".")),true);
                                 outputStream.write(convertedData);
                                 outputStream.flush();
                                 outputStream.close();
@@ -240,17 +242,18 @@ public class EncryptionManager {
 
     public void decryptData(String fileName, SecureCipher.SecureDecryptionCallback callback) {
         try {
-            SecureContextCompat secureContext = new SecureContextCompat(context);
+            SecureContextCompat secureContext = new SecureContextCompat(context,SecureConfig.getDefault());
             secureContext.openEncryptedFileInput(
                     fileName,
                     Executors.newSingleThreadExecutor(),
+                    true,
                     inputStream -> {
                 try {
 
                     byte[] encodedData = new byte[inputStream.available()];
                     inputStream.read(encodedData);
                     inputStream.close();
-                    SecureCipher secureCipher = SecureCipher.getDefault(biometricSupport);
+                    SecureCipher secureCipher = SecureCipher.getDefault(SecureConfig.getDefault(biometricSupport));
                     secureCipher.decryptEncodedData(encodedData, callback);
                 } catch (IOException ex) {
                     Log.e(TAG, "There was a problem writing to file... " + ex.getMessage());

--- a/niap-cc/NIAPSecExample/app/src/main/java/com/android/certifications/niap/MainActivity.java
+++ b/niap-cc/NIAPSecExample/app/src/main/java/com/android/certifications/niap/MainActivity.java
@@ -156,21 +156,16 @@ public class MainActivity extends FragmentActivity {
                     SecureURL secureURL = new SecureURL("https://www.google.com", null);
                     URLConnection conn = secureURL.openConnection();
                     conn.connect();
-                } catch (MalformedURLException ex) {
+                } catch(Exception ex) {
                     Log.e(TAG, "SecureURL Failure: " + ex.getMessage());
-                    Log.e(TAG, ex.toString());
-                } catch (IOException e) {
-                    e.printStackTrace();
+                    Log.e(TAG, ex.getStackTrace().toString());
                 }
-
             }
         });
         executor.shutdown();
         try {
             future.get();
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        } catch (ExecutionException e) {
+        } catch (InterruptedException | ExecutionException e) {
             e.printStackTrace();
         }
 

--- a/niap-cc/NIAPSecExample/app/src/main/java/com/android/certifications/niap/tests/SDPAuthFailureTestWorker.java
+++ b/niap-cc/NIAPSecExample/app/src/main/java/com/android/certifications/niap/tests/SDPAuthFailureTestWorker.java
@@ -74,7 +74,7 @@ public class SDPAuthFailureTestWorker extends Worker {
             TestUtil.logSuccess(getClass(), "Writing Data: " + TestUtil.DATA,
                     FileOutputStream.class);
             FileOutputStream outputStream = secureContext.openEncryptedFileOutput(FILE_NAME,
-                    Context.MODE_PRIVATE, KEY_PAIR_ALIAS);
+                    Context.MODE_PRIVATE, true);//KEY_PAIR_ALIAS);
             TestUtil.logSuccess(getClass(), "Writing SDP file encrypted contents to " +
                     FILE_NAME, Cipher.class);
             outputStream.write(TestUtil.DATA.getBytes(StandardCharsets.UTF_8));
@@ -94,6 +94,7 @@ public class SDPAuthFailureTestWorker extends Worker {
             secureContext.openEncryptedFileInput(
                     FILE_NAME,
                     Executors.newSingleThreadExecutor(),
+                    true,
                     inputStream -> {
                 try {
                     byte[] encodedData = new byte[inputStream.available()];

--- a/niap-cc/NIAPSecExample/app/src/main/java/com/android/certifications/niap/tests/SDPTestWorker.java
+++ b/niap-cc/NIAPSecExample/app/src/main/java/com/android/certifications/niap/tests/SDPTestWorker.java
@@ -67,7 +67,7 @@ public class SDPTestWorker extends Worker {
             // Write SDP File
             BiometricSupport biometricSupport = new BiometricSupportImpl(
                     MainActivity.thisActivity,
-                    getApplicationContext()) {
+                    getApplicationContext(),false) {
                 @Override
                 public void onAuthenticationSucceeded() {
                     TestUtil.logSuccess(getClass(), "SDP Biometric Unlock Succeeded, " +
@@ -77,12 +77,6 @@ public class SDPTestWorker extends Worker {
                 @Override
                 public void onAuthenticationFailed() {
                     TestUtil.logFailure(getClass(), "SDP Biometric Unlock failed, " +
-                            "file not available for decryption.");
-                }
-
-                @Override
-                public void onAuthenticationCancelled() {
-                    TestUtil.logFailure(getClass(), "SDP Biometric Unlock cancelled, " +
                             "file not available for decryption.");
                 }
 
@@ -114,7 +108,7 @@ public class SDPTestWorker extends Worker {
                     FileOutputStream.class);
             FileOutputStream outputStream = secureContext.openEncryptedFileOutput(
                     FILE_NAME,
-                    Context.MODE_PRIVATE, KEY_PAIR_ALIAS);
+                    Context.MODE_PRIVATE, KEY_PAIR_ALIAS,true);
             TestUtil.logSuccess(
                     getClass(),
                     "Writing SDP file encrypted contents to " + FILE_NAME,
@@ -136,6 +130,7 @@ public class SDPTestWorker extends Worker {
             secureContext.openEncryptedFileInput(
                     FILE_NAME,
                     Executors.newSingleThreadExecutor(),
+                    true,
                     inputStream -> {
                 try {
                     byte[] encodedData = new byte[inputStream.available()];

--- a/niap-cc/NIAPSecExample/build.gradle
+++ b/niap-cc/NIAPSecExample/build.gradle
@@ -22,8 +22,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.0.0"
-
+        classpath 'com.android.tools.build:gradle:4.0.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
**Changes :** 
- Fit interfaces to new NIAPSec libraries.
- Update target SDK version to 33
- Use ExecutorService instead of AsyncTask

**Concerns :**
We need to update the "buildToolsVersion" of NIAP-SEC library to compile this project,
at least in my environment.