### PR TITLE
Hubble: Upgrade build environment and app.

### DIFF
--- a/uraniborg/AndroidStudioProject/Hubble/app/build.gradle
+++ b/uraniborg/AndroidStudioProject/Hubble/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
     defaultConfig {
         applicationId "com.uraniborg.hubble"
         minSdkVersion 23
-        targetSdkVersion 33
-        versionCode 4
-        versionName "1.2.0"
+        targetSdkVersion 34
+        versionCode 5
+        versionName "1.3.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
@@ -20,6 +20,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    namespace 'com.uraniborg.hubble'
 }
 
 dependencies {

--- a/uraniborg/AndroidStudioProject/Hubble/app/src/main/AndroidManifest.xml
+++ b/uraniborg/AndroidStudioProject/Hubble/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.uraniborg.hubble">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/uraniborg/AndroidStudioProject/Hubble/app/src/main/java/com/uraniborg/hubble/MainActivity.java
+++ b/uraniborg/AndroidStudioProject/Hubble/app/src/main/java/com/uraniborg/hubble/MainActivity.java
@@ -44,7 +44,10 @@ import java.util.Locale;
 
 public class MainActivity extends AppCompatActivity {
   final String TAG = "HUBBLE";
-  private final String VERSION = "1.3.0";   // NOTE: to be updated for every Hubble release
+
+  // semantically tie the notion of app version to versionName, which we will update for every
+  // major and minor release, instead of independently and separately update these values everytime.
+  private final String VERSION = BuildConfig.VERSION_NAME;
 
   private HashMap<String, PackageMetadata> mAllPackages;
   private HashMap<String, byte[]> mAllCertificates;

--- a/uraniborg/AndroidStudioProject/Hubble/app/src/main/java/com/uraniborg/hubble/MainActivity.java
+++ b/uraniborg/AndroidStudioProject/Hubble/app/src/main/java/com/uraniborg/hubble/MainActivity.java
@@ -44,7 +44,7 @@ import java.util.Locale;
 
 public class MainActivity extends AppCompatActivity {
   final String TAG = "HUBBLE";
-  private final String VERSION = "1.2.0";   // NOTE: to be updated for every Hubble release
+  private final String VERSION = "1.3.0";   // NOTE: to be updated for every Hubble release
 
   private HashMap<String, PackageMetadata> mAllPackages;
   private HashMap<String, byte[]> mAllCertificates;

--- a/uraniborg/AndroidStudioProject/Hubble/build.gradle
+++ b/uraniborg/AndroidStudioProject/Hubble/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.2.2'
         
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/uraniborg/AndroidStudioProject/Hubble/gradle.properties
+++ b/uraniborg/AndroidStudioProject/Hubble/gradle.properties
@@ -17,4 +17,7 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false
 

--- a/uraniborg/AndroidStudioProject/Hubble/gradle/wrapper/gradle-wrapper.properties
+++ b/uraniborg/AndroidStudioProject/Hubble/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip


### PR DESCRIPTION
App:
- update app from SDK 33 to 34
- bumped versionCode to 5
- bumped versionName to "1.3.0"
- removed package name from AndroidManifest.xml

Build environment:
- Updated build gradle to 8.2.2
- Bumped gradle distribution Url to to 8.2
- added package name as namespace in build.gradle

Test:
Hubble APK was rebuild and tested with `automate_observation.py` on a Pixel 8 running Android 14 with build fingerprint:
google/shiba/shiba:14/UQ1A.240105.004/11206848:user/release-keys.